### PR TITLE
feat: define python-data-v1 Profile Bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,57 @@ jobs:
 
       - name: Run repository checks
         run: make check
+
+  profile-bundle:
+    name: Profile Bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Download locked Runtime Profile inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_cache="$RUNNER_TEMP/profile-sources"
+          mkdir -p "$source_cache"
+
+          python_archive="$source_cache/cpython-3.14.7+20260825-x86_64-unknown-linux-musl-install_only_stripped.tar.gz"
+          curl --fail --location --retry 3 \
+            --output "$python_archive" \
+            'https://github.com/astral-sh/python-build-standalone/releases/download/20260825/cpython-3.14.7%2B20260825-x86_64-unknown-linux-musl-install_only_stripped.tar.gz'
+          echo "22374158b61f9415135614fb7ebdba498a84849921bb5ad025809e925d8bb428  $python_archive" | sha256sum --check --strict
+
+          musl_archive="$source_cache/alpine-minirootfs-3.22.5-x86_64.tar.gz"
+          curl --fail --location --retry 3 \
+            --output "$musl_archive" \
+            'https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/x86_64/alpine-minirootfs-3.22.5-x86_64.tar.gz'
+          echo "4b4daa9fe2fc696c4919c4412a4c3d3e770d8fb70292a004a2c72f5096175282  $musl_archive" | sha256sum --check --strict
+
+      - name: Build Profile Bundle test commands
+        shell: bash
+        run: |
+          set -euo pipefail
+          go build -o "$RUNNER_TEMP/profile-bundle" ./cmd/profile-bundle
+          go test -c \
+            -tags='profilebundle_root profilebundle_production' \
+            -o "$RUNNER_TEMP/profile-bundle-tests" \
+            ./tests
+
+      - name: Verify Profile Bundle on Linux as root
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo -n unshare --net env \
+            PROFILE_BUNDLE_CLI="$RUNNER_TEMP/profile-bundle" \
+            PROFILE_BUNDLE_REPOSITORY_ROOT="$GITHUB_WORKSPACE" \
+            PROFILE_BUNDLE_SOURCE_CACHE="$RUNNER_TEMP/profile-sources" \
+            "$RUNNER_TEMP/profile-bundle-tests" \
+            -test.v \
+            -test.run='^(TestProfileBundleInstall|TestPythonDataV1Production)'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 - `with_Go`：保留原有调用方式的兼容入口。
 - `with_shell`：Shell 版对照实验；仅用于教学和行为比较。
 - `tests`：面向公开命令入口的 Linux 验收测试。
+- `cmd/profile-bundle`：构建和 root-owned 安装 `python-data-v1` Profile Bundle 的公开工具。
+- `profiles/python-data-v1`：锁定的 Runtime Profile 输入与候选 System Call Policy。
 - `docs/adr` 与 `CONTEXT.md`：目标系统的架构决策和上下文文档。
 
 ## Linux 前置条件
@@ -39,6 +41,8 @@ bash -n with_shell/*.sh
 ```
 
 GitHub Actions 会在 Ubuntu 上对 push 和 pull request 执行同一个 `make check`，因此本地与 CI 使用相同的验收入口。
+
+Profile Bundle 另有一个 Linux root 验收 job：它校验锁定下载、两次可复现构建、root-owned 原子安装、恶意 Bundle 拒绝以及真实 CPython 内容 smoke。格式和命令合同见 [`docs/profile-bundle-v1.md`](docs/profile-bundle-v1.md)。
 
 ## 使用 Go Runtime Lab
 

--- a/cmd/profile-bundle/main.go
+++ b/cmd/profile-bundle/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/TH1NKING/Build-your-own-Docker-with-Go/internal/profilebundle"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "profile-bundle:", err)
+		os.Exit(1)
+	}
+}
+
+func run(arguments []string) error {
+	if len(arguments) == 0 {
+		return errors.New("expected a subcommand: build or install")
+	}
+
+	switch arguments[0] {
+	case "build":
+		return runBuild(arguments[1:])
+	case "install":
+		return runInstall(arguments[1:])
+	default:
+		return fmt.Errorf("unknown subcommand %q", arguments[0])
+	}
+}
+
+func runBuild(arguments []string) error {
+	flags := flag.NewFlagSet("profile-bundle build", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+
+	var options profilebundle.BuildOptions
+	flags.StringVar(&options.LockPath, "lock", "", "path to the reviewed profile build lock")
+	flags.StringVar(&options.SourceCache, "source-cache", "", "directory containing locked source artifacts")
+	flags.StringVar(&options.SystemCallPolicyPath, "system-call-policy", "", "path to the reviewed System Call Policy")
+	flags.StringVar(&options.SandboxInitPath, "sandbox-init", "", "path to the externally supplied Sandbox Init")
+	flags.StringVar(&options.OutputPath, "output", "", "path for the deterministic Profile Bundle")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %v", flags.Args())
+	}
+
+	digest, err := profilebundle.Build(options)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stdout, digest)
+	return nil
+}
+
+func runInstall(arguments []string) error {
+	flags := flag.NewFlagSet("profile-bundle install", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+
+	var options profilebundle.InstallOptions
+	flags.StringVar(&options.BundlePath, "bundle", "", "path to the Profile Bundle")
+	flags.StringVar(&options.ExpectedSHA256, "expected-sha256", "", "trusted SHA-256 of the complete Profile Bundle")
+	flags.StringVar(&options.StorePath, "store", "", "absolute path to the root-owned Profile store")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %v", flags.Args())
+	}
+
+	installedPath, err := profilebundle.Install(options)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stdout, installedPath)
+	return nil
+}

--- a/docs/profile-bundle-v1.md
+++ b/docs/profile-bundle-v1.md
@@ -1,0 +1,141 @@
+# Profile Bundle v1
+
+Profile Bundle v1 is the published build and installation contract for the
+`python-data-v1` Runtime Profile. It is intentionally narrow: the format binds
+one locked Linux root filesystem, one externally supplied Sandbox Init, and one
+System Call Policy. It does not define Sandbox Init behavior or enforce the
+System Call Policy.
+
+## Trust and identity
+
+The complete Bundle is identified by the SHA-256 of its exact bytes. `build`
+prints that lowercase 64-character digest. A Worker installation must obtain
+the expected digest from trusted configuration and pass it explicitly to
+`install`; component digests inside the Bundle prove internal consistency but
+are not an independent trust anchor.
+
+The installer publishes a verified Bundle at:
+
+```text
+<profile-store>/sha256/<bundle-sha256>/
+```
+
+It never accepts an installation path from Bundle contents and never replaces
+an existing identity. Reinstalling the same digest succeeds only after the
+newly verified staging tree and the existing tree compare exactly.
+
+## Canonical outer format
+
+The Bundle is an uncompressed POSIX tar with these entries in this exact order:
+
+```text
+manifest.json
+profile.lock.json
+system-call-policy.json
+sandbox-init
+rootfs.tar
+```
+
+All entries are regular files owned by numeric UID/GID zero, use an epoch
+timestamp, and have canonical modes: metadata and `rootfs.tar` are `0444`, and
+Sandbox Init is `0555`. Missing, duplicate, reordered, altered, or additional
+entries are invalid.
+
+`manifest.json` uses schema `profile-bundle-manifest/v1`. It fixes the profile
+to `python-data-v1`, the target to `linux/amd64`, the Python version and
+entrypoint, and the closed component list. Every component record contains its
+role, path, format, installed mode, byte size, and `sha256:<lowercase-hex>`
+digest. The manifest does not contain the Bundle digest, avoiding a
+self-referential identity.
+
+The System Call Policy envelope is versioned as well. Each rule contains
+sorted syscall `names`, the `allow` action, and zero or more argument
+predicates. A predicate fixes an argument index from 0 through 5, one supported
+comparison operator, a value, and a mask used only by `masked-equal`. T02
+validates and binds this schema; T08 remains responsible for reviewing the
+actual calls and applying the rules to the kernel.
+
+## Canonical root filesystem
+
+`rootfs.tar` is a deterministic PAX tar. Entries are sorted by slash-relative
+path and normalized to UID/GID zero, epoch time, and read-only modes. Version 1
+allows regular files and relative in-root symbolic links. Hard links, devices,
+FIFOs, sockets, set-ID bits, absolute paths, dot segments, and escaping links
+are rejected.
+
+The installer verifies the complete `rootfs.tar` component before parsing it.
+It then extracts into a new root-only staging directory, creates symbolic links
+only after regular files, makes directories read-only from the leaves upward,
+syncs the result, and atomically renames the completed tree into the
+content-addressed store. A failure can leave no selectable final directory.
+If syncing the publication directory fails after rename, the installer first
+renames the identity back into staging and removes it before reporting failure;
+an additional rollback failure is reported explicitly as an uncertain host
+filesystem failure.
+
+Version 1 bounds one source artifact to 256 MiB, one root-filesystem file to
+256 MiB, the normalized root filesystem to 1 GiB and 100,000 entries, and paths
+to 4,096 bytes with 255-byte segments. These format-safety bounds are distinct
+from the smaller runtime Resource Budget enforced by later execution tickets.
+
+Read-only mounting, User Namespaces, `pivot_root`, and old-root detachment are
+owned by T04. System Call Policy enforcement, `no_new_privs`, and capability
+removal are owned by T08.
+
+## Locked production inputs
+
+[`profiles/python-data-v1/profile.lock.json`](../profiles/python-data-v1/profile.lock.json)
+is the reviewed build input. Every external artifact has an exact version,
+immutable URL, byte size, and SHA-256:
+
+- CPython 3.14.7 from the 2026-08-25 `python-build-standalone` release;
+- the musl 1.2.5 runtime loader from Alpine 3.22.5 minirootfs.
+
+The first profile deliberately declares no third-party Python packages. It
+retains standard-library data facilities such as CSV, JSON, and SQLite. `pip`,
+`ensurepip`, and the noninteractive profile's unused terminfo database are
+excluded by the reviewed recipe. Adding dependencies changes the reviewed
+input and Bundle identity; broadening the System Call Policy requires a new
+Runtime Profile version after T08 conformance.
+
+The current System Call Policy is a default-deny candidate with no allow rules.
+It is format-valid and digest-bound, but the profile must not be promoted for
+Workload execution until T08 supplies and verifies the reviewed allowlist on a
+real Linux kernel.
+
+## Commands
+
+Prepare the exact files named in the lock in a trusted source cache, verifying
+their sizes and SHA-256 values before use. Building itself performs no network
+access:
+
+```text
+profile-bundle build \
+  --lock profiles/python-data-v1/profile.lock.json \
+  --source-cache <verified-source-cache> \
+  --system-call-policy profiles/python-data-v1/system-call-policy.json \
+  --sandbox-init <externally-supplied-init> \
+  --output python-data-v1.bundle
+```
+
+Installation is Linux-only, must run as root, and requires an existing
+root-owned store that is not writable by group or other:
+
+```text
+profile-bundle install \
+  --bundle python-data-v1.bundle \
+  --expected-sha256 <trusted-bundle-sha256> \
+  --store /var/lib/agent-sandbox/profiles
+```
+
+On success, `install` prints the relative immutable identity
+`sha256/<bundle-sha256>`, not a re-resolved absolute path. Callers keep the
+trusted Profile store handle/configuration separate from that identity.
+
+Windows can build and inspect deterministic Bundle bytes from locked source
+archives. It cannot substantiate root ownership or Linux atomic installation;
+those properties are required CI checks on Ubuntu.
+
+CI downloads and verifies the locked inputs before entering a new network
+namespace. Both production builds and the chroot content smoke therefore run
+without network access and assert reviewed rootfs and Policy component digests.

--- a/internal/profilebundle/build.go
+++ b/internal/profilebundle/build.go
@@ -1,0 +1,918 @@
+package profilebundle
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	buildLockSchema    = "profile-build-lock/v1"
+	manifestSchema     = "profile-bundle-manifest/v1"
+	profileID          = "python-data-v1"
+	maximumInputSize   = 256 << 20
+	maximumInitSize    = 64 << 20
+	maximumPolicySize  = 1 << 20
+	maximumRootFSSize  = 1 << 30
+	maximumRootFSFile  = 256 << 20
+	maximumRootFSItems = 100000
+	maximumPathLength  = 4096
+)
+
+var canonicalTime = time.Unix(0, 0).UTC()
+
+type bundlePart struct {
+	component component
+	contents  []byte
+	filePath  string
+}
+
+type rootfsBuildEntry struct {
+	name     string
+	typeFlag byte
+	mode     int64
+	size     int64
+	linkName string
+	spool    string
+}
+
+type rootfsBuildBudget struct {
+	scannedItems int
+	scannedBytes int64
+	outputItems  int
+	outputBytes  int64
+}
+
+func Build(options BuildOptions) (string, error) {
+	if err := validateBuildOptions(options); err != nil {
+		return "", err
+	}
+
+	lock, lockBytes, err := readBuildLock(options.LockPath)
+	if err != nil {
+		return "", err
+	}
+	policyBytes, err := readSystemCallPolicy(options.SystemCallPolicyPath)
+	if err != nil {
+		return "", err
+	}
+	initBytes, err := readRegularFile(options.SandboxInitPath, maximumInitSize, "Sandbox Init")
+	if err != nil {
+		return "", err
+	}
+	if len(initBytes) == 0 {
+		return "", errors.New("Sandbox Init must not be empty")
+	}
+
+	rootfsFile, err := os.CreateTemp(filepath.Dir(options.OutputPath), ".python-data-v1-rootfs-*.tar")
+	if err != nil {
+		return "", fmt.Errorf("create root filesystem component: %w", err)
+	}
+	rootfsPath := rootfsFile.Name()
+	defer os.Remove(rootfsPath)
+	if err := rootfsFile.Close(); err != nil {
+		return "", fmt.Errorf("close root filesystem component: %w", err)
+	}
+	if err := buildRootFS(options.SourceCache, rootfsPath, lock); err != nil {
+		return "", err
+	}
+
+	rootfsInfo, err := os.Stat(rootfsPath)
+	if err != nil {
+		return "", fmt.Errorf("stat root filesystem component: %w", err)
+	}
+	rootfsDigest, err := digestFile(rootfsPath)
+	if err != nil {
+		return "", err
+	}
+
+	parts := []bundlePart{
+		newMemoryPart(bundleV1Components[0], lockBytes),
+		newMemoryPart(bundleV1Components[1], policyBytes),
+		newMemoryPart(bundleV1Components[2], initBytes),
+		{
+			component: component{
+				Role:   bundleV1Components[3].Role,
+				Path:   bundleV1Components[3].Path,
+				Format: bundleV1Components[3].Format,
+				Mode:   bundleV1Components[3].Mode,
+				Size:   rootfsInfo.Size(),
+				Digest: "sha256:" + rootfsDigest,
+			},
+			filePath: rootfsPath,
+		},
+	}
+	manifestBytes, err := canonicalJSON(manifest{
+		Schema:     manifestSchema,
+		Profile:    profileID,
+		Target:     lock.Target,
+		Python:     lock.Python,
+		Components: components(parts),
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode Profile Bundle manifest: %w", err)
+	}
+
+	digest, err := writeBundle(options.OutputPath, manifestBytes, parts)
+	if err != nil {
+		return "", err
+	}
+	return digest, nil
+}
+
+func readSystemCallPolicy(policyPath string) ([]byte, error) {
+	policyBytes, err := readRegularFile(policyPath, maximumPolicySize, "System Call Policy")
+	if err != nil {
+		return nil, err
+	}
+	return decodeSystemCallPolicy(policyBytes)
+}
+
+func decodeSystemCallPolicy(policyBytes []byte) ([]byte, error) {
+	decoder := json.NewDecoder(bytes.NewReader(policyBytes))
+	decoder.DisallowUnknownFields()
+	var policy systemCallPolicy
+	if err := decoder.Decode(&policy); err != nil {
+		return nil, fmt.Errorf("decode System Call Policy: %w", err)
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return nil, fmt.Errorf("decode System Call Policy: %w", err)
+	}
+	if policy.Schema != "system-call-policy/v1" || policy.Profile != profileID ||
+		policy.Target.OS != "linux" || policy.Target.Arch != "amd64" {
+		return nil, errors.New("System Call Policy must target system-call-policy/v1 for python-data-v1 on linux/amd64")
+	}
+	if policy.DefaultAction.Action != "errno" || policy.DefaultAction.Errno <= 0 {
+		return nil, errors.New("System Call Policy must provide a nonzero default errno action")
+	}
+	if err := validateSystemCallRules(policy.Rules); err != nil {
+		return nil, err
+	}
+	canonical, err := canonicalJSON(policy)
+	if err != nil {
+		return nil, fmt.Errorf("encode canonical System Call Policy: %w", err)
+	}
+	return canonical, nil
+}
+
+func validateSystemCallRules(rules []systemCallPolicyRule) error {
+	if rules == nil {
+		return errors.New("System Call Policy rules must be an explicit JSON array")
+	}
+	lastRuleName := ""
+	for ruleIndex, rule := range rules {
+		if len(rule.Names) == 0 || rule.Action != "allow" {
+			return errors.New("System Call Policy rules must name syscalls and use the allow action")
+		}
+		for nameIndex, name := range rule.Names {
+			if !validSystemCallName(name) {
+				return errors.New("System Call Policy syscall names may contain only lowercase ASCII letters, digits, and underscores")
+			}
+			if nameIndex > 0 && rule.Names[nameIndex-1] >= name {
+				return errors.New("System Call Policy syscall names must be unique and in bytewise order")
+			}
+		}
+		if ruleIndex > 0 && lastRuleName >= rule.Names[0] {
+			return errors.New("System Call Policy rules must be in bytewise syscall order")
+		}
+		lastRuleName = rule.Names[len(rule.Names)-1]
+		if rule.Arguments == nil {
+			return errors.New("System Call Policy rule arguments must be an explicit JSON array")
+		}
+		for argumentIndex, argument := range rule.Arguments {
+			if argument.Index > 5 {
+				return errors.New("System Call Policy argument index must be between 0 and 5")
+			}
+			if argumentIndex > 0 && rule.Arguments[argumentIndex-1].Index >= argument.Index {
+				return errors.New("System Call Policy arguments must have unique increasing indexes")
+			}
+			switch argument.Operator {
+			case "equal", "not-equal", "less-than", "less-or-equal", "greater-than", "greater-or-equal":
+				if argument.Mask != 0 {
+					return errors.New("System Call Policy argument mask is valid only with masked-equal")
+				}
+			case "masked-equal":
+				if argument.Mask == 0 {
+					return errors.New("System Call Policy masked-equal argument requires a nonzero mask")
+				}
+			default:
+				return fmt.Errorf("unsupported System Call Policy argument operator %q", argument.Operator)
+			}
+		}
+	}
+	return nil
+}
+
+func validSystemCallName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, character := range name {
+		if character >= 'a' && character <= 'z' || character >= '0' && character <= '9' || character == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validateBuildOptions(options BuildOptions) error {
+	missing := make([]string, 0, 5)
+	for name, value := range map[string]string{
+		"--lock":               options.LockPath,
+		"--source-cache":       options.SourceCache,
+		"--system-call-policy": options.SystemCallPolicyPath,
+		"--sandbox-init":       options.SandboxInitPath,
+		"--output":             options.OutputPath,
+	} {
+		if value == "" {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) != 0 {
+		return fmt.Errorf("missing required options: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func readBuildLock(lockPath string) (buildLock, []byte, error) {
+	lockBytes, err := readRegularFile(lockPath, maximumPolicySize, "profile build lock")
+	if err != nil {
+		return buildLock{}, nil, err
+	}
+	return decodeBuildLock(lockBytes)
+}
+
+func decodeBuildLock(lockBytes []byte) (buildLock, []byte, error) {
+	decoder := json.NewDecoder(bytes.NewReader(lockBytes))
+	decoder.DisallowUnknownFields()
+	var lock buildLock
+	if err := decoder.Decode(&lock); err != nil {
+		return buildLock{}, nil, fmt.Errorf("decode profile build lock: %w", err)
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return buildLock{}, nil, fmt.Errorf("decode profile build lock: %w", err)
+	}
+	if err := validateBuildLock(lock); err != nil {
+		return buildLock{}, nil, err
+	}
+	canonical, err := canonicalJSON(lock)
+	if err != nil {
+		return buildLock{}, nil, fmt.Errorf("encode profile build lock: %w", err)
+	}
+	return lock, canonical, nil
+}
+
+func validateBuildLock(lock buildLock) error {
+	if lock.Schema != buildLockSchema {
+		return fmt.Errorf("unsupported profile build lock schema %q", lock.Schema)
+	}
+	if lock.Profile != profileID {
+		return fmt.Errorf("profile build lock selects %q, want %q", lock.Profile, profileID)
+	}
+	if lock.Target.OS != "linux" || lock.Target.Arch != "amd64" {
+		return fmt.Errorf("profile build lock target is %s/%s, want linux/amd64", lock.Target.OS, lock.Target.Arch)
+	}
+	if lock.Python.Version == "" || lock.Python.Entrypoint == "" {
+		return errors.New("profile build lock must pin Python version and entrypoint")
+	}
+	if !path.IsAbs(lock.Python.Entrypoint) || validateRelativePath(strings.TrimPrefix(lock.Python.Entrypoint, "/")) != nil {
+		return errors.New("profile build lock Python entrypoint must be a canonical absolute path")
+	}
+	for index, pythonPackage := range lock.Python.Packages {
+		if pythonPackage.Name == "" || pythonPackage.Version == "" {
+			return errors.New("profile build lock Python packages must pin name and version")
+		}
+		if index > 0 && lock.Python.Packages[index-1].Name >= pythonPackage.Name {
+			return errors.New("profile build lock Python packages must have unique names in bytewise order")
+		}
+		if strings.Contains(strings.ToLower(pythonPackage.Version), "latest") || strings.ContainsAny(pythonPackage.Version, "*<>, ") {
+			return fmt.Errorf("profile build lock Python package %q version must be exact", pythonPackage.Name)
+		}
+		if _, err := parseDigest(pythonPackage.Digest); err != nil {
+			return fmt.Errorf("profile build lock Python package %q digest: %w", pythonPackage.Name, err)
+		}
+	}
+	if len(lock.Inputs) == 0 {
+		return errors.New("profile build lock must declare at least one external input")
+	}
+	for index, input := range lock.Inputs {
+		if index > 0 && lock.Inputs[index-1].ID >= input.ID {
+			return errors.New("profile build lock inputs must have unique IDs in bytewise order")
+		}
+		if err := validateLockedInput(input); err != nil {
+			return fmt.Errorf("profile build lock input %q: %w", input.ID, err)
+		}
+	}
+	return nil
+}
+
+func validateLockedInput(input lockedInput) error {
+	if input.ID == "" || input.Version == "" || input.Filename == "" {
+		return errors.New("id, version, and filename are required")
+	}
+	if input.Kind != "python-install-only" && input.Kind != "rootfs-overlay" {
+		return fmt.Errorf("unsupported kind %q", input.Kind)
+	}
+	if strings.Contains(strings.ToLower(input.Version), "latest") || strings.ContainsAny(input.Version, "*<>, ") {
+		return errors.New("version must be exact and must not be floating")
+	}
+	parsedSource, err := url.Parse(input.Source)
+	if err != nil || parsedSource.Scheme != "https" || parsedSource.Host == "" {
+		return errors.New("source must be an absolute HTTPS URL")
+	}
+	if filepath.Base(input.Filename) != input.Filename {
+		return errors.New("filename must not contain a path")
+	}
+	if input.Size <= 0 || input.Size > maximumInputSize {
+		return fmt.Errorf("size must be between 1 and %d bytes", maximumInputSize)
+	}
+	if _, err := parseDigest(input.Digest); err != nil {
+		return fmt.Errorf("digest: %w", err)
+	}
+	if input.ArchivePrefix != "" && !safeArchivePrefix(input.ArchivePrefix) {
+		return errors.New("archive prefix must be empty or a safe relative directory path")
+	}
+	if input.Destination != "" && !safeArchivePrefix(input.Destination) {
+		return errors.New("destination must be empty or a safe relative directory path")
+	}
+	if err := validatePathList("include", input.Include); err != nil {
+		return err
+	}
+	if err := validatePathList("exclude", input.Exclude); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validatePathList(name string, values []string) error {
+	for index, value := range values {
+		if err := validateRelativePath(value); err != nil {
+			return fmt.Errorf("%s path %q: %w", name, value, err)
+		}
+		if index > 0 && values[index-1] >= value {
+			return fmt.Errorf("%s paths must be unique and in bytewise order", name)
+		}
+	}
+	return nil
+}
+
+func buildRootFS(sourceCache, outputPath string, lock buildLock) error {
+	spoolDirectory, err := os.MkdirTemp(filepath.Dir(outputPath), ".python-data-v1-rootfs-spool-*")
+	if err != nil {
+		return fmt.Errorf("create root filesystem spool: %w", err)
+	}
+	defer os.RemoveAll(spoolDirectory)
+
+	entries := make([]rootfsBuildEntry, 0)
+	seenEntrypoint := false
+	budget := rootfsBuildBudget{}
+	for _, input := range lock.Inputs {
+		sourcePath := filepath.Join(sourceCache, input.Filename)
+		providedEntrypoint, err := spoolLockedInput(sourcePath, spoolDirectory, input, lock.Python.Entrypoint, &entries, &budget)
+		if err != nil {
+			return err
+		}
+		seenEntrypoint = seenEntrypoint || providedEntrypoint
+	}
+	if !seenEntrypoint {
+		return fmt.Errorf("locked inputs do not provide entrypoint %q", lock.Python.Entrypoint)
+	}
+	sort.Slice(entries, func(left, right int) bool {
+		return entries[left].name < entries[right].name
+	})
+	for index := 1; index < len(entries); index++ {
+		if entries[index-1].name == entries[index].name {
+			return fmt.Errorf("locked inputs map more than one entry to %q", entries[index].name)
+		}
+	}
+	if err := validateRootFSItemClosure(entries); err != nil {
+		return err
+	}
+	if err := validateRootFSEntrypoint(entries, lock.Python.Entrypoint); err != nil {
+		return err
+	}
+
+	output, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_TRUNC, 0)
+	if err != nil {
+		return fmt.Errorf("open root filesystem component: %w", err)
+	}
+	tarWriter := tar.NewWriter(output)
+	for _, entry := range entries {
+		canonical := canonicalTarHeader(entry.name, entry.typeFlag, entry.mode, entry.size, entry.linkName)
+		if err := tarWriter.WriteHeader(canonical); err != nil {
+			output.Close()
+			return fmt.Errorf("write root filesystem entry %q: %w", entry.name, err)
+		}
+		if entry.typeFlag != tar.TypeReg {
+			continue
+		}
+		spool, err := os.Open(entry.spool)
+		if err != nil {
+			output.Close()
+			return fmt.Errorf("open spooled root filesystem file %q: %w", entry.name, err)
+		}
+		if _, err := io.CopyN(tarWriter, spool, entry.size); err != nil {
+			spool.Close()
+			output.Close()
+			return fmt.Errorf("write root filesystem contents %q: %w", entry.name, err)
+		}
+		if err := spool.Close(); err != nil {
+			output.Close()
+			return fmt.Errorf("close spooled root filesystem file %q: %w", entry.name, err)
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		output.Close()
+		return fmt.Errorf("close root filesystem tar: %w", err)
+	}
+	if err := output.Sync(); err != nil {
+		output.Close()
+		return fmt.Errorf("sync root filesystem tar: %w", err)
+	}
+	if err := output.Close(); err != nil {
+		return fmt.Errorf("close root filesystem tar: %w", err)
+	}
+	return nil
+}
+
+func validateRootFSItemClosure(entries []rootfsBuildEntry) error {
+	directories := make(map[string]struct{})
+	entryPaths := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		entryPaths[entry.name] = struct{}{}
+	}
+	for _, entry := range entries {
+		directory := path.Dir(entry.name)
+		current := ""
+		for _, segment := range strings.Split(directory, "/") {
+			if segment == "." {
+				continue
+			}
+			if current == "" {
+				current = segment
+			} else {
+				current = path.Join(current, segment)
+			}
+			if _, occupied := entryPaths[current]; occupied {
+				return fmt.Errorf("root filesystem entry %q cannot be the parent of %q", current, entry.name)
+			}
+			directories[current] = struct{}{}
+			if len(entries)+len(directories) > maximumRootFSItems {
+				return fmt.Errorf("root filesystem files, links, and implicit directories exceed the v1 limit of %d entries", maximumRootFSItems)
+			}
+		}
+	}
+	return nil
+}
+
+func validateRootFSEntrypoint(entries []rootfsBuildEntry, entrypoint string) error {
+	byName := make(map[string]rootfsBuildEntry, len(entries))
+	for _, entry := range entries {
+		byName[entry.name] = entry
+	}
+	current := strings.TrimPrefix(entrypoint, "/")
+	for range 40 {
+		entry, ok := byName[current]
+		if !ok {
+			return fmt.Errorf("Python entrypoint %q is missing from the locked root filesystem", entrypoint)
+		}
+		switch entry.typeFlag {
+		case tar.TypeReg:
+			if entry.mode != 0o555 {
+				return fmt.Errorf("Python entrypoint %q does not resolve to an executable regular file", entrypoint)
+			}
+			return nil
+		case tar.TypeSymlink:
+			current = path.Clean(path.Join(path.Dir(current), entry.linkName))
+			if err := validateRelativePath(current); err != nil {
+				return fmt.Errorf("Python entrypoint %q has an unsafe symlink chain: %w", entrypoint, err)
+			}
+		default:
+			return fmt.Errorf("Python entrypoint %q has an unsupported file type", entrypoint)
+		}
+	}
+	return fmt.Errorf("Python entrypoint %q has a symbolic-link cycle", entrypoint)
+}
+
+func spoolLockedInput(sourcePath, spoolDirectory string, input lockedInput, entrypoint string, entries *[]rootfsBuildEntry, budget *rootfsBuildBudget) (bool, error) {
+	sourceBytes, err := readLockedSource(sourcePath, input)
+	if err != nil {
+		return false, err
+	}
+	gzipReader, err := gzip.NewReader(bytes.NewReader(sourceBytes))
+	if err != nil {
+		return false, fmt.Errorf("open locked source %q: %w", input.ID, err)
+	}
+	defer gzipReader.Close()
+
+	sourceTar := tar.NewReader(gzipReader)
+	seenEntrypoint := false
+	for {
+		header, err := sourceTar.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return false, fmt.Errorf("read locked source %q: %w", input.ID, err)
+		}
+		budget.scannedItems++
+		if budget.scannedItems > maximumRootFSItems {
+			return false, fmt.Errorf("locked sources exceed the v1 scan limit of %d entries", maximumRootFSItems)
+		}
+		if header.Size < 0 || budget.scannedBytes > maximumRootFSSize-header.Size {
+			return false, fmt.Errorf("locked sources exceed the v1 scan budget of %d bytes", maximumRootFSSize)
+		}
+		budget.scannedBytes += header.Size
+		mappedName, include, err := mapSourcePath(header.Name, input)
+		if err != nil {
+			return false, err
+		}
+		if !include {
+			continue
+		}
+
+		switch header.Typeflag {
+		case tar.TypeDir:
+			continue
+		case tar.TypeReg, tar.TypeRegA:
+			if header.Size > maximumRootFSFile || budget.outputBytes > maximumRootFSSize-header.Size {
+				return false, fmt.Errorf("root filesystem file %q exceeds the v1 size budget", mappedName)
+			}
+			budget.outputBytes += header.Size
+			mode := int64(0o444)
+			if header.Mode&0o111 != 0 {
+				mode = 0o555
+			}
+			spool, err := os.CreateTemp(spoolDirectory, "entry-*")
+			if err != nil {
+				return false, fmt.Errorf("spool root filesystem file %q: %w", mappedName, err)
+			}
+			spoolPath := spool.Name()
+			if _, err := io.CopyN(spool, sourceTar, header.Size); err != nil {
+				spool.Close()
+				return false, fmt.Errorf("spool root filesystem contents %q: %w", mappedName, err)
+			}
+			if err := spool.Close(); err != nil {
+				return false, fmt.Errorf("close spooled root filesystem file %q: %w", mappedName, err)
+			}
+			*entries = append(*entries, rootfsBuildEntry{
+				name:     mappedName,
+				typeFlag: tar.TypeReg,
+				mode:     mode,
+				size:     header.Size,
+				spool:    spoolPath,
+			})
+		case tar.TypeSymlink:
+			if err := validateSymlink(mappedName, header.Linkname); err != nil {
+				return false, err
+			}
+			*entries = append(*entries, rootfsBuildEntry{
+				name:     mappedName,
+				typeFlag: tar.TypeSymlink,
+				mode:     0o555,
+				linkName: header.Linkname,
+			})
+		default:
+			return false, fmt.Errorf("locked source %q entry %q has unsupported type %d", input.ID, header.Name, header.Typeflag)
+		}
+		budget.outputItems++
+		if budget.outputItems > maximumRootFSItems {
+			return false, fmt.Errorf("root filesystem exceeds the v1 limit of %d entries", maximumRootFSItems)
+		}
+		if "/"+mappedName == entrypoint {
+			seenEntrypoint = true
+		}
+	}
+	return seenEntrypoint, nil
+}
+
+func readLockedSource(sourcePath string, input lockedInput) ([]byte, error) {
+	file, err := os.Open(sourcePath)
+	if err != nil {
+		return nil, fmt.Errorf("open locked source %q: %w", input.ID, err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat locked source %q: %w", input.ID, err)
+	}
+	if !info.Mode().IsRegular() || info.Size() != input.Size {
+		return nil, fmt.Errorf("locked source %q must be a regular file of exactly %d bytes", input.ID, input.Size)
+	}
+	contents, err := io.ReadAll(io.LimitReader(file, input.Size+1))
+	if err != nil {
+		return nil, fmt.Errorf("read locked source %q: %w", input.ID, err)
+	}
+	if int64(len(contents)) != input.Size {
+		return nil, fmt.Errorf("locked source %q changed while being read", input.ID)
+	}
+	wantDigest, _ := parseDigest(input.Digest)
+	if actualDigest := digestBytes(contents); actualDigest != wantDigest {
+		return nil, fmt.Errorf("locked source %q SHA-256 is %s, want %s", input.ID, actualDigest, wantDigest)
+	}
+	return contents, nil
+}
+
+func mapSourcePath(sourceName string, input lockedInput) (string, bool, error) {
+	normalizedSource := strings.TrimPrefix(sourceName, "./")
+	normalizedSource = strings.TrimSuffix(normalizedSource, "/")
+	if normalizedSource == "" {
+		return "", false, nil
+	}
+	if err := validateRelativePath(normalizedSource); err != nil {
+		return "", false, fmt.Errorf("locked source %q entry %q: %w", input.ID, sourceName, err)
+	}
+	relative := normalizedSource
+	if input.ArchivePrefix != "" {
+		if !strings.HasPrefix(normalizedSource, input.ArchivePrefix) {
+			return "", false, nil
+		}
+		relative = strings.TrimPrefix(normalizedSource, input.ArchivePrefix)
+	}
+	if relative == "" {
+		return "", false, nil
+	}
+	if err := validateRelativePath(relative); err != nil {
+		return "", false, fmt.Errorf("locked source %q entry %q: %w", input.ID, sourceName, err)
+	}
+	if len(input.Include) != 0 && !pathSelected(relative, input.Include) {
+		return "", false, nil
+	}
+	for _, excluded := range input.Exclude {
+		if relative == excluded || strings.HasPrefix(relative, strings.TrimSuffix(excluded, "/")+"/") {
+			return "", false, nil
+		}
+	}
+	mapped := relative
+	if input.Destination != "" {
+		mapped = path.Join(strings.TrimSuffix(input.Destination, "/"), relative)
+	}
+	if err := validateRelativePath(mapped); err != nil {
+		return "", false, fmt.Errorf("mapped root filesystem entry %q: %w", mapped, err)
+	}
+	return mapped, true, nil
+}
+
+func pathSelected(relative string, included []string) bool {
+	for _, candidate := range included {
+		if relative == candidate || strings.HasPrefix(relative, candidate+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func validateSymlink(name, target string) error {
+	if target == "" || path.IsAbs(target) || strings.Contains(target, "\\") {
+		return fmt.Errorf("root filesystem symlink %q has unsafe target %q", name, target)
+	}
+	resolved := path.Clean(path.Join(path.Dir(name), target))
+	if resolved == ".." || strings.HasPrefix(resolved, "../") {
+		return fmt.Errorf("root filesystem symlink %q escapes through target %q", name, target)
+	}
+	return nil
+}
+
+func canonicalTarHeader(name string, typeFlag byte, mode, size int64, linkName string) *tar.Header {
+	return &tar.Header{
+		Name:       name,
+		Linkname:   linkName,
+		Size:       size,
+		Mode:       mode,
+		Uid:        0,
+		Gid:        0,
+		Uname:      "",
+		Gname:      "",
+		ModTime:    canonicalTime,
+		AccessTime: time.Time{},
+		ChangeTime: time.Time{},
+		Typeflag:   typeFlag,
+		Format:     tar.FormatPAX,
+	}
+}
+
+func newMemoryPart(contract component, contents []byte) bundlePart {
+	return bundlePart{
+		component: component{
+			Role:   contract.Role,
+			Path:   contract.Path,
+			Format: contract.Format,
+			Mode:   contract.Mode,
+			Size:   int64(len(contents)),
+			Digest: "sha256:" + digestBytes(contents),
+		},
+		contents: contents,
+	}
+}
+
+func components(parts []bundlePart) []component {
+	result := make([]component, len(parts))
+	for index := range parts {
+		result[index] = parts[index].component
+	}
+	return result
+}
+
+func writeBundle(outputPath string, manifestBytes []byte, parts []bundlePart) (string, error) {
+	if _, err := os.Lstat(outputPath); err == nil {
+		return "", fmt.Errorf("output %q already exists", outputPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("inspect output %q: %w", outputPath, err)
+	}
+	outputDirectory := filepath.Dir(outputPath)
+	temporary, err := os.CreateTemp(outputDirectory, ".profile-bundle-*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("create temporary Profile Bundle: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	temporaryClosed := false
+	defer func() {
+		if !temporaryClosed {
+			temporary.Close()
+		}
+	}()
+
+	digest := sha256.New()
+	tarWriter := tar.NewWriter(io.MultiWriter(temporary, digest))
+	if err := writeOuterEntry(tarWriter, "manifest.json", 0o444, manifestBytes, ""); err != nil {
+		return "", err
+	}
+	for _, part := range parts {
+		if part.filePath == "" {
+			if err := writeOuterEntry(tarWriter, part.component.Path, parseMode(part.component.Mode), part.contents, ""); err != nil {
+				return "", err
+			}
+			continue
+		}
+		file, err := os.Open(part.filePath)
+		if err != nil {
+			return "", fmt.Errorf("open component %q: %w", part.component.Role, err)
+		}
+		header := canonicalTarHeader(part.component.Path, tar.TypeReg, parseMode(part.component.Mode), part.component.Size, "")
+		header.Format = tar.FormatUSTAR
+		if err := tarWriter.WriteHeader(header); err != nil {
+			file.Close()
+			return "", fmt.Errorf("write component %q header: %w", part.component.Role, err)
+		}
+		if _, err := io.CopyN(tarWriter, file, part.component.Size); err != nil {
+			file.Close()
+			return "", fmt.Errorf("write component %q: %w", part.component.Role, err)
+		}
+		if err := file.Close(); err != nil {
+			return "", fmt.Errorf("close component %q: %w", part.component.Role, err)
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		return "", fmt.Errorf("close Profile Bundle tar: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return "", fmt.Errorf("sync Profile Bundle: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return "", fmt.Errorf("close Profile Bundle: %w", err)
+	}
+	temporaryClosed = true
+	if err := os.Link(temporaryPath, outputPath); err != nil {
+		return "", fmt.Errorf("publish Profile Bundle: %w", err)
+	}
+	if err := syncDirectory(outputDirectory); err != nil {
+		if removeErr := os.Remove(outputPath); removeErr != nil {
+			return "", fmt.Errorf("publish Profile Bundle: %v; remove unsynced output: %w", err, removeErr)
+		}
+		return "", fmt.Errorf("publish Profile Bundle: %w", err)
+	}
+	_ = os.Remove(temporaryPath)
+	return hex.EncodeToString(digest.Sum(nil)), nil
+}
+
+func writeOuterEntry(writer *tar.Writer, name string, mode int64, contents []byte, linkName string) error {
+	header := canonicalTarHeader(name, tar.TypeReg, mode, int64(len(contents)), linkName)
+	header.Format = tar.FormatUSTAR
+	if err := writer.WriteHeader(header); err != nil {
+		return fmt.Errorf("write Profile Bundle entry %q header: %w", name, err)
+	}
+	if _, err := writer.Write(contents); err != nil {
+		return fmt.Errorf("write Profile Bundle entry %q: %w", name, err)
+	}
+	return nil
+}
+
+func parseMode(mode string) int64 {
+	if mode == "0555" {
+		return 0o555
+	}
+	return 0o444
+}
+
+func canonicalJSON(value any) ([]byte, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	return append(encoded, '\n'), nil
+}
+
+func requireJSONEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return err
+	}
+	return nil
+}
+
+func parseDigest(value string) (string, error) {
+	if !strings.HasPrefix(value, "sha256:") {
+		return "", errors.New("must use sha256:<lowercase-hex>")
+	}
+	hexDigest := strings.TrimPrefix(value, "sha256:")
+	decoded, err := hex.DecodeString(hexDigest)
+	if err != nil || len(decoded) != sha256.Size || hexDigest != strings.ToLower(hexDigest) {
+		return "", errors.New("must use sha256:<64-lowercase-hex>")
+	}
+	return hexDigest, nil
+}
+
+func digestBytes(contents []byte) string {
+	digest := sha256.Sum256(contents)
+	return hex.EncodeToString(digest[:])
+}
+
+func digestFile(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("open %q for SHA-256: %w", filePath, err)
+	}
+	defer file.Close()
+	digest := sha256.New()
+	if _, err := io.Copy(digest, file); err != nil {
+		return "", fmt.Errorf("calculate SHA-256 for %q: %w", filePath, err)
+	}
+	return hex.EncodeToString(digest.Sum(nil)), nil
+}
+
+func readRegularFile(filePath string, maximumSize int64, description string) ([]byte, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", description, err)
+	}
+	defer file.Close()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat opened %s: %w", description, err)
+	}
+	pathInfo, err := os.Lstat(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("lstat %s after opening: %w", description, err)
+	}
+	if !openedInfo.Mode().IsRegular() || !pathInfo.Mode().IsRegular() || !os.SameFile(openedInfo, pathInfo) {
+		return nil, fmt.Errorf("%s must be a regular file", description)
+	}
+	if openedInfo.Size() < 0 || openedInfo.Size() > maximumSize {
+		return nil, fmt.Errorf("%s exceeds %d bytes", description, maximumSize)
+	}
+	contents, err := io.ReadAll(io.LimitReader(file, maximumSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", description, err)
+	}
+	if int64(len(contents)) != openedInfo.Size() {
+		return nil, fmt.Errorf("%s changed while being read", description)
+	}
+	return contents, nil
+}
+
+func safeArchivePrefix(value string) bool {
+	return strings.HasSuffix(value, "/") && validateRelativePath(strings.TrimSuffix(value, "/")) == nil
+}
+
+func validateRelativePath(value string) error {
+	if value == "" || len(value) > maximumPathLength || path.IsAbs(value) || strings.Contains(value, "\\") || strings.ContainsRune(value, 0) {
+		return errors.New("path must be a non-empty slash-relative path")
+	}
+	if path.Clean(value) != value {
+		return errors.New("path must be canonical and contain no dot segments")
+	}
+	for _, segment := range strings.Split(value, "/") {
+		if segment == "" || len(segment) > 255 || segment == "." || segment == ".." {
+			return errors.New("path contains an unsafe segment")
+		}
+	}
+	return nil
+}

--- a/internal/profilebundle/install_linux.go
+++ b/internal/profilebundle/install_linux.go
@@ -1,0 +1,795 @@
+//go:build linux
+
+package profilebundle
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+)
+
+const maximumBundleSize = 2 << 30
+
+type pendingSymlink struct {
+	name   string
+	target string
+}
+
+type installedEntryFingerprint struct {
+	name   string
+	mode   fs.FileMode
+	size   int64
+	uid    uint32
+	gid    uint32
+	digest [sha256.Size]byte
+	link   string
+}
+
+func Install(options InstallOptions) (installedPath string, returnErr error) {
+	if os.Geteuid() != 0 {
+		return "", errors.New("Profile Bundle installation requires root")
+	}
+	if options.BundlePath == "" || options.ExpectedSHA256 == "" || options.StorePath == "" {
+		return "", errors.New("install requires --bundle, --expected-sha256, and --store")
+	}
+	if !filepath.IsAbs(options.StorePath) {
+		return "", errors.New("Profile store path must be absolute")
+	}
+	expectedDigest, err := parseExpectedSHA256(options.ExpectedSHA256)
+	if err != nil {
+		return "", err
+	}
+	storeRoot, err := os.OpenRoot(options.StorePath)
+	if err != nil {
+		return "", fmt.Errorf("open Profile store: %w", err)
+	}
+	defer storeRoot.Close()
+	if err := validateOpenedProfileStore(options.StorePath, storeRoot); err != nil {
+		return "", err
+	}
+	if err := ensureStoreDirectory(storeRoot, ".staging", 0o700); err != nil {
+		return "", err
+	}
+	if err := ensureStoreDirectory(storeRoot, "sha256", 0o755); err != nil {
+		return "", err
+	}
+
+	stageName, err := randomStageName()
+	if err != nil {
+		return "", err
+	}
+	stageRelative := path.Join(".staging", stageName)
+	if err := storeRoot.Mkdir(stageRelative, 0o700); err != nil {
+		return "", fmt.Errorf("create installation staging directory: %w", err)
+	}
+	published := false
+	defer func() {
+		if published {
+			return
+		}
+		if cleanupErr := storeRoot.RemoveAll(stageRelative); cleanupErr != nil && returnErr == nil {
+			returnErr = fmt.Errorf("clean installation staging directory: %w", cleanupErr)
+		}
+	}()
+
+	stageRoot, err := storeRoot.OpenRoot(stageRelative)
+	if err != nil {
+		return "", fmt.Errorf("open installation staging directory: %w", err)
+	}
+	archive, actualDigest, err := copyApprovedBundle(stageRoot, options.BundlePath)
+	if err != nil {
+		stageRoot.Close()
+		return "", err
+	}
+	if actualDigest != expectedDigest {
+		archive.Close()
+		stageRoot.Close()
+		return "", fmt.Errorf("Profile Bundle SHA-256 is %s, want %s", actualDigest, expectedDigest)
+	}
+	if _, err := archive.Seek(0, io.SeekStart); err != nil {
+		archive.Close()
+		stageRoot.Close()
+		return "", fmt.Errorf("rewind approved Profile Bundle: %w", err)
+	}
+	if err := extractApprovedBundle(stageRoot, archive); err != nil {
+		archive.Close()
+		stageRoot.Close()
+		return "", err
+	}
+	if err := archive.Close(); err != nil {
+		stageRoot.Close()
+		return "", fmt.Errorf("close approved Profile Bundle: %w", err)
+	}
+	if err := stageRoot.Remove("bundle.tar"); err != nil {
+		stageRoot.Close()
+		return "", fmt.Errorf("remove staged transport archive: %w", err)
+	}
+	stageDirectory, err := stageRoot.Open(".")
+	if err != nil {
+		stageRoot.Close()
+		return "", fmt.Errorf("open completed staging directory: %w", err)
+	}
+	if err := stageDirectory.Chmod(0o555); err != nil {
+		stageDirectory.Close()
+		stageRoot.Close()
+		return "", fmt.Errorf("make completed staging directory immutable: %w", err)
+	}
+	if err := stageDirectory.Sync(); err != nil {
+		stageDirectory.Close()
+		stageRoot.Close()
+		return "", fmt.Errorf("sync completed staging directory: %w", err)
+	}
+	if err := stageDirectory.Close(); err != nil {
+		stageRoot.Close()
+		return "", fmt.Errorf("close completed staging directory: %w", err)
+	}
+	if err := stageRoot.Close(); err != nil {
+		return "", fmt.Errorf("close installation staging root: %w", err)
+	}
+
+	finalRelative := path.Join("sha256", expectedDigest)
+	shaDirectory, err := storeRoot.Open("sha256")
+	if err != nil {
+		return "", fmt.Errorf("open Profile store identity directory: %w", err)
+	}
+	stagingDirectory, err := storeRoot.Open(".staging")
+	if err != nil {
+		shaDirectory.Close()
+		return "", fmt.Errorf("open Profile store staging directory: %w", err)
+	}
+	if err := storeRoot.Rename(stageRelative, finalRelative); err != nil {
+		shaDirectory.Close()
+		stagingDirectory.Close()
+		equal, comparisonErr := installedTreesEqual(storeRoot, stageRelative, finalRelative)
+		if comparisonErr != nil || !equal {
+			if comparisonErr != nil {
+				return "", fmt.Errorf("publish installed Profile Bundle: %w; verify existing identity: %v", err, comparisonErr)
+			}
+			return "", fmt.Errorf("publish installed Profile Bundle: %w; existing identity has different contents", err)
+		}
+		return finalRelative, nil
+	}
+	if err := shaDirectory.Sync(); err != nil {
+		shaDirectory.Close()
+		stagingDirectory.Close()
+		commitErr := fmt.Errorf("sync Profile store identity directory: %w", err)
+		if rollbackErr := storeRoot.Rename(finalRelative, stageRelative); rollbackErr != nil {
+			published = true
+			return "", fmt.Errorf("%v; rollback published Profile: %w", commitErr, rollbackErr)
+		}
+		return "", commitErr
+	}
+	if err := stagingDirectory.Sync(); err != nil {
+		shaDirectory.Close()
+		stagingDirectory.Close()
+		commitErr := fmt.Errorf("sync Profile store staging directory: %w", err)
+		if rollbackErr := storeRoot.Rename(finalRelative, stageRelative); rollbackErr != nil {
+			published = true
+			return "", fmt.Errorf("%v; rollback published Profile: %w", commitErr, rollbackErr)
+		}
+		return "", commitErr
+	}
+	shaCloseErr := shaDirectory.Close()
+	stagingCloseErr := stagingDirectory.Close()
+	if shaCloseErr != nil || stagingCloseErr != nil {
+		closeErr := errors.Join(shaCloseErr, stagingCloseErr)
+		commitErr := fmt.Errorf("close synced Profile store directories: %w", closeErr)
+		if rollbackErr := storeRoot.Rename(finalRelative, stageRelative); rollbackErr != nil {
+			published = true
+			return "", fmt.Errorf("%v; rollback published Profile: %w", commitErr, rollbackErr)
+		}
+		return "", commitErr
+	}
+	published = true
+	return finalRelative, nil
+}
+
+func installedTreesEqual(storeRoot *os.Root, leftName, rightName string) (bool, error) {
+	left, err := storeRoot.OpenRoot(leftName)
+	if err != nil {
+		return false, fmt.Errorf("open staged installed tree: %w", err)
+	}
+	defer left.Close()
+	right, err := storeRoot.OpenRoot(rightName)
+	if err != nil {
+		return false, fmt.Errorf("open existing installed tree: %w", err)
+	}
+	defer right.Close()
+
+	leftEntries, err := fingerprintInstalledTree(left)
+	if err != nil {
+		return false, fmt.Errorf("fingerprint staged installed tree: %w", err)
+	}
+	rightEntries, err := fingerprintInstalledTree(right)
+	if err != nil {
+		return false, fmt.Errorf("fingerprint existing installed tree: %w", err)
+	}
+	if len(leftEntries) != len(rightEntries) {
+		return false, nil
+	}
+	for index := range leftEntries {
+		if leftEntries[index] != rightEntries[index] {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func fingerprintInstalledTree(root *os.Root) ([]installedEntryFingerprint, error) {
+	entries := make([]installedEntryFingerprint, 0)
+	err := fs.WalkDir(root.FS(), ".", func(name string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		info, err := root.Lstat(name)
+		if err != nil {
+			return err
+		}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("entry %q has no Linux ownership metadata", name)
+		}
+		fingerprint := installedEntryFingerprint{
+			name: name,
+			mode: info.Mode(),
+			size: info.Size(),
+			uid:  stat.Uid,
+			gid:  stat.Gid,
+		}
+		switch {
+		case info.Mode().IsRegular():
+			file, err := root.Open(name)
+			if err != nil {
+				return err
+			}
+			digest := sha256.New()
+			if _, err := io.Copy(digest, file); err != nil {
+				file.Close()
+				return err
+			}
+			if err := file.Close(); err != nil {
+				return err
+			}
+			copy(fingerprint.digest[:], digest.Sum(nil))
+		case info.Mode()&os.ModeSymlink != 0:
+			fingerprint.link, err = root.Readlink(name)
+			if err != nil {
+				return err
+			}
+		case info.IsDir():
+		default:
+			return fmt.Errorf("installed entry %q has unsupported type %v", name, info.Mode().Type())
+		}
+		entries = append(entries, fingerprint)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func parseExpectedSHA256(value string) (string, error) {
+	if len(value) != sha256.Size*2 || value != strings.ToLower(value) {
+		return "", errors.New("expected Profile Bundle SHA-256 must be 64 lowercase hexadecimal characters")
+	}
+	decoded, err := hex.DecodeString(value)
+	if err != nil || len(decoded) != sha256.Size {
+		return "", errors.New("expected Profile Bundle SHA-256 must be 64 lowercase hexadecimal characters")
+	}
+	return value, nil
+}
+
+func validateOpenedProfileStore(storePath string, root *os.Root) error {
+	directory, err := root.Open(".")
+	if err != nil {
+		return fmt.Errorf("open Profile store directory handle: %w", err)
+	}
+	openedInfo, err := directory.Stat()
+	if err != nil {
+		directory.Close()
+		return fmt.Errorf("stat opened Profile store: %w", err)
+	}
+	if err := directory.Close(); err != nil {
+		return fmt.Errorf("close Profile store directory handle: %w", err)
+	}
+	pathInfo, err := os.Lstat(storePath)
+	if err != nil {
+		return fmt.Errorf("lstat Profile store after opening: %w", err)
+	}
+	if !pathInfo.IsDir() || pathInfo.Mode()&os.ModeSymlink != 0 || !openedInfo.IsDir() {
+		return errors.New("Profile store must be an existing directory, not a symbolic link")
+	}
+	openedStat, openedOK := openedInfo.Sys().(*syscall.Stat_t)
+	pathStat, pathOK := pathInfo.Sys().(*syscall.Stat_t)
+	if !openedOK || !pathOK || openedStat.Dev != pathStat.Dev || openedStat.Ino != pathStat.Ino {
+		return errors.New("Profile store path changed while its directory handle was opened")
+	}
+	if openedStat.Uid != 0 || openedStat.Gid != 0 {
+		return errors.New("Profile store must be owned by root:root")
+	}
+	if openedInfo.Mode().Perm()&0o022 != 0 {
+		return errors.New("Profile store must not be writable by group or other")
+	}
+	return nil
+}
+
+func ensureStoreDirectory(root *os.Root, name string, mode os.FileMode) error {
+	if err := root.Mkdir(name, mode); err != nil && !errors.Is(err, os.ErrExist) {
+		return fmt.Errorf("create Profile store directory %q: %w", name, err)
+	}
+	info, err := root.Lstat(name)
+	if err != nil {
+		return fmt.Errorf("stat Profile store directory %q: %w", name, err)
+	}
+	if !info.IsDir() || info.Mode().Perm() != mode {
+		return fmt.Errorf("Profile store directory %q must be a directory with mode %04o", name, mode)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat.Uid != 0 || stat.Gid != 0 {
+		return fmt.Errorf("Profile store directory %q must be owned by root:root", name)
+	}
+	return nil
+}
+
+func randomStageName() (string, error) {
+	value := make([]byte, 16)
+	if _, err := rand.Read(value); err != nil {
+		return "", fmt.Errorf("generate installation staging name: %w", err)
+	}
+	return hex.EncodeToString(value), nil
+}
+
+func copyApprovedBundle(stageRoot *os.Root, bundlePath string) (*os.File, string, error) {
+	input, err := os.Open(bundlePath)
+	if err != nil {
+		return nil, "", fmt.Errorf("open Profile Bundle: %w", err)
+	}
+	defer input.Close()
+	info, err := input.Stat()
+	if err != nil {
+		return nil, "", fmt.Errorf("stat Profile Bundle: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > maximumBundleSize {
+		return nil, "", fmt.Errorf("Profile Bundle must be a regular file between 1 and %d bytes", maximumBundleSize)
+	}
+
+	archive, err := stageRoot.OpenFile("bundle.tar", os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o400)
+	if err != nil {
+		return nil, "", fmt.Errorf("create staged Profile Bundle: %w", err)
+	}
+	digest := sha256.New()
+	written, err := io.Copy(io.MultiWriter(archive, digest), io.LimitReader(input, maximumBundleSize+1))
+	if err != nil {
+		archive.Close()
+		return nil, "", fmt.Errorf("copy Profile Bundle to private staging: %w", err)
+	}
+	if written != info.Size() {
+		archive.Close()
+		return nil, "", errors.New("Profile Bundle changed while being copied to private staging")
+	}
+	if err := archive.Sync(); err != nil {
+		archive.Close()
+		return nil, "", fmt.Errorf("sync staged Profile Bundle: %w", err)
+	}
+	return archive, hex.EncodeToString(digest.Sum(nil)), nil
+}
+
+func extractApprovedBundle(stageRoot *os.Root, archive *os.File) error {
+	archiveInfo, err := archive.Stat()
+	if err != nil {
+		return fmt.Errorf("stat approved Profile Bundle: %w", err)
+	}
+	reader := tar.NewReader(archive)
+	manifestHeader, err := reader.Next()
+	if err != nil {
+		return fmt.Errorf("read Profile Bundle manifest header: %w", err)
+	}
+	if err := validateOuterHeader(manifestHeader, "manifest.json", 0o444, manifestHeader.Size); err != nil {
+		return err
+	}
+	if manifestHeader.Size <= 0 || manifestHeader.Size > maximumPolicySize {
+		return errors.New("Profile Bundle manifest has an invalid size")
+	}
+	manifestBytes, err := io.ReadAll(io.LimitReader(reader, manifestHeader.Size+1))
+	if err != nil {
+		return fmt.Errorf("read Profile Bundle manifest: %w", err)
+	}
+	if int64(len(manifestBytes)) != manifestHeader.Size {
+		return errors.New("Profile Bundle manifest size does not match its header")
+	}
+	bundleManifest, err := decodeManifest(manifestBytes)
+	if err != nil {
+		return err
+	}
+	if err := writeInstalledBytes(stageRoot, "manifest.json", manifestBytes, 0o444); err != nil {
+		return err
+	}
+
+	for _, declared := range bundleManifest.Components {
+		header, err := reader.Next()
+		if err != nil {
+			return fmt.Errorf("read component %q header: %w", declared.Role, err)
+		}
+		mode := parseMode(declared.Mode)
+		if err := validateOuterHeader(header, declared.Path, mode, declared.Size); err != nil {
+			return err
+		}
+		file, err := stageRoot.OpenFile(declared.Path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err != nil {
+			return fmt.Errorf("create staged component %q: %w", declared.Role, err)
+		}
+		digest := sha256.New()
+		written, copyErr := io.CopyN(io.MultiWriter(file, digest), reader, declared.Size)
+		if copyErr != nil {
+			file.Close()
+			return fmt.Errorf("read component %q: %w", declared.Role, copyErr)
+		}
+		if written != declared.Size || "sha256:"+hex.EncodeToString(digest.Sum(nil)) != declared.Digest {
+			file.Close()
+			return fmt.Errorf("component %q does not match its declared size and SHA-256", declared.Role)
+		}
+		if err := file.Chmod(os.FileMode(mode)); err != nil {
+			file.Close()
+			return fmt.Errorf("set component %q mode: %w", declared.Role, err)
+		}
+		if err := file.Sync(); err != nil {
+			file.Close()
+			return fmt.Errorf("sync component %q: %w", declared.Role, err)
+		}
+		if err := file.Close(); err != nil {
+			return fmt.Errorf("close component %q: %w", declared.Role, err)
+		}
+	}
+	if header, err := reader.Next(); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("Profile Bundle contains unlisted outer entry %q", header.Name)
+		}
+		return fmt.Errorf("finish Profile Bundle: %w", err)
+	}
+	if archiveInfo.Size() != canonicalOuterTarSize(manifestHeader.Size, bundleManifest.Components) {
+		return errors.New("Profile Bundle has non-canonical framing or trailing data")
+	}
+	policyBytes, err := stageRoot.ReadFile("system-call-policy.json")
+	if err != nil {
+		return fmt.Errorf("read installed System Call Policy: %w", err)
+	}
+	canonicalPolicy, err := decodeSystemCallPolicy(policyBytes)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(policyBytes, canonicalPolicy) {
+		return errors.New("Profile Bundle System Call Policy is not canonical JSON")
+	}
+	lockBytes, err := stageRoot.ReadFile("profile.lock.json")
+	if err != nil {
+		return fmt.Errorf("read installed profile build lock: %w", err)
+	}
+	lock, canonicalLock, err := decodeBuildLock(lockBytes)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(lockBytes, canonicalLock) {
+		return errors.New("Profile Bundle build lock is not canonical JSON")
+	}
+	if bundleManifest.Target != lock.Target || !pythonRuntimeEqual(bundleManifest.Python, lock.Python) {
+		return errors.New("Profile Bundle manifest target and Python contract must exactly match the build lock")
+	}
+	return extractRootFS(stageRoot, lock.Python.Entrypoint)
+}
+
+func canonicalOuterTarSize(manifestSize int64, components []component) int64 {
+	total := tarEntryStorageSize(manifestSize) + 2*512
+	for _, declared := range components {
+		total += tarEntryStorageSize(declared.Size)
+	}
+	return total
+}
+
+func tarEntryStorageSize(size int64) int64 {
+	return 512 + ((size + 511) / 512 * 512)
+}
+
+func pythonRuntimeEqual(left, right pythonRuntime) bool {
+	if left.Version != right.Version || left.Entrypoint != right.Entrypoint || len(left.Packages) != len(right.Packages) {
+		return false
+	}
+	for index := range left.Packages {
+		if left.Packages[index] != right.Packages[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func decodeManifest(contents []byte) (manifest, error) {
+	decoder := json.NewDecoder(bytes.NewReader(contents))
+	decoder.DisallowUnknownFields()
+	var decoded manifest
+	if err := decoder.Decode(&decoded); err != nil {
+		return manifest{}, fmt.Errorf("decode Profile Bundle manifest: %w", err)
+	}
+	if err := requireJSONEOF(decoder); err != nil {
+		return manifest{}, fmt.Errorf("decode Profile Bundle manifest: %w", err)
+	}
+	if decoded.Schema != manifestSchema || decoded.Profile != profileID || decoded.Target.OS != "linux" || decoded.Target.Arch != "amd64" {
+		return manifest{}, errors.New("Profile Bundle manifest selects an unsupported schema, profile, or target")
+	}
+	expected := bundleV1Components
+	if len(decoded.Components) != len(expected) {
+		return manifest{}, errors.New("Profile Bundle manifest must declare the closed v1 component set")
+	}
+	for index, want := range expected {
+		got := decoded.Components[index]
+		if got.Role != want.Role || got.Path != want.Path || got.Format != want.Format || got.Mode != want.Mode || got.Size <= 0 {
+			return manifest{}, fmt.Errorf("Profile Bundle component %d does not match the closed v1 contract", index)
+		}
+		if _, err := parseDigest(got.Digest); err != nil {
+			return manifest{}, fmt.Errorf("Profile Bundle component %q digest: %w", got.Role, err)
+		}
+	}
+	canonical, err := canonicalJSON(decoded)
+	if err != nil {
+		return manifest{}, fmt.Errorf("encode canonical Profile Bundle manifest: %w", err)
+	}
+	if !bytes.Equal(contents, canonical) {
+		return manifest{}, errors.New("Profile Bundle manifest is not canonical JSON")
+	}
+	return decoded, nil
+}
+
+func validateOuterHeader(header *tar.Header, name string, mode, size int64) error {
+	if header.Name != name || header.Typeflag != tar.TypeReg || header.Mode != mode || header.Size != size ||
+		header.Uid != 0 || header.Gid != 0 || header.Uname != "" || header.Gname != "" ||
+		header.Devmajor != 0 || header.Devminor != 0 || !header.ModTime.Equal(canonicalTime) ||
+		!header.AccessTime.IsZero() || !header.ChangeTime.IsZero() || len(header.PAXRecords) != 0 ||
+		header.Format != tar.FormatUSTAR {
+		return fmt.Errorf("Profile Bundle entry %q has non-canonical metadata", header.Name)
+	}
+	return nil
+}
+
+func writeInstalledBytes(root *os.Root, name string, contents []byte, mode os.FileMode) error {
+	file, err := root.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("create installed %q: %w", name, err)
+	}
+	if _, err := file.Write(contents); err != nil {
+		file.Close()
+		return fmt.Errorf("write installed %q: %w", name, err)
+	}
+	if err := file.Chmod(mode); err != nil {
+		file.Close()
+		return fmt.Errorf("set installed %q mode: %w", name, err)
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return fmt.Errorf("sync installed %q: %w", name, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close installed %q: %w", name, err)
+	}
+	return nil
+}
+
+func extractRootFS(stageRoot *os.Root, entrypoint string) error {
+	if err := stageRoot.Mkdir("rootfs", 0o700); err != nil {
+		return fmt.Errorf("create installed root filesystem: %w", err)
+	}
+	root, err := stageRoot.OpenRoot("rootfs")
+	if err != nil {
+		return fmt.Errorf("open installed root filesystem: %w", err)
+	}
+	defer root.Close()
+	component, err := stageRoot.Open("rootfs.tar")
+	if err != nil {
+		return fmt.Errorf("open verified root filesystem component: %w", err)
+	}
+	defer component.Close()
+	originalDigest := sha256.New()
+	if _, err := io.Copy(originalDigest, component); err != nil {
+		return fmt.Errorf("hash verified root filesystem component: %w", err)
+	}
+	if _, err := component.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind verified root filesystem component: %w", err)
+	}
+	canonicalDigest := sha256.New()
+	canonicalWriter := tar.NewWriter(canonicalDigest)
+
+	reader := tar.NewReader(component)
+	directories := map[string]struct{}{".": {}}
+	entryTypes := make(map[string]byte)
+	symlinks := make([]pendingSymlink, 0)
+	lastName := ""
+	itemCount := 0
+	var unpackedBytes int64
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read verified root filesystem component: %w", err)
+		}
+		if err := validateRelativePath(header.Name); err != nil {
+			return fmt.Errorf("root filesystem entry %q: %w", header.Name, err)
+		}
+		if lastName != "" && header.Name <= lastName {
+			return errors.New("root filesystem entries must be unique and sorted")
+		}
+		lastName = header.Name
+		itemCount++
+		if itemCount > maximumRootFSItems {
+			return fmt.Errorf("root filesystem exceeds the v1 limit of %d entries", maximumRootFSItems)
+		}
+		if header.Uid != 0 || header.Gid != 0 || !header.ModTime.Equal(canonicalTime) {
+			return fmt.Errorf("root filesystem entry %q has non-canonical ownership or time", header.Name)
+		}
+		if err := ensureRootFSParents(root, path.Dir(header.Name), directories, entryTypes); err != nil {
+			return err
+		}
+		if itemCount+len(directories)-1 > maximumRootFSItems {
+			return fmt.Errorf("root filesystem files, links, and implicit directories exceed the v1 limit of %d entries", maximumRootFSItems)
+		}
+
+		switch header.Typeflag {
+		case tar.TypeReg, tar.TypeRegA:
+			if header.Typeflag != tar.TypeReg || header.Mode != 0o444 && header.Mode != 0o555 {
+				return fmt.Errorf("root filesystem file %q has unsafe mode %04o", header.Name, header.Mode)
+			}
+			if header.Size < 0 || header.Size > maximumRootFSFile || unpackedBytes > maximumRootFSSize-header.Size {
+				return fmt.Errorf("root filesystem file %q exceeds the v1 size budget", header.Name)
+			}
+			unpackedBytes += header.Size
+			if err := canonicalWriter.WriteHeader(canonicalTarHeader(header.Name, tar.TypeReg, header.Mode, header.Size, "")); err != nil {
+				return fmt.Errorf("canonicalize root filesystem file %q: %w", header.Name, err)
+			}
+			file, err := root.OpenFile(header.Name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+			if err != nil {
+				return fmt.Errorf("create root filesystem file %q: %w", header.Name, err)
+			}
+			if _, err := io.CopyN(io.MultiWriter(file, canonicalWriter), reader, header.Size); err != nil {
+				file.Close()
+				return fmt.Errorf("write root filesystem file %q: %w", header.Name, err)
+			}
+			if err := file.Chmod(os.FileMode(header.Mode)); err != nil {
+				file.Close()
+				return fmt.Errorf("set root filesystem file %q mode: %w", header.Name, err)
+			}
+			if err := file.Sync(); err != nil {
+				file.Close()
+				return fmt.Errorf("sync root filesystem file %q: %w", header.Name, err)
+			}
+			if err := file.Close(); err != nil {
+				return fmt.Errorf("close root filesystem file %q: %w", header.Name, err)
+			}
+			entryTypes[header.Name] = tar.TypeReg
+		case tar.TypeSymlink:
+			if header.Mode != 0o555 {
+				return fmt.Errorf("root filesystem symlink %q has unsafe mode %04o", header.Name, header.Mode)
+			}
+			if err := validateSymlink(header.Name, header.Linkname); err != nil {
+				return err
+			}
+			if err := canonicalWriter.WriteHeader(canonicalTarHeader(header.Name, tar.TypeSymlink, 0o555, 0, header.Linkname)); err != nil {
+				return fmt.Errorf("canonicalize root filesystem symlink %q: %w", header.Name, err)
+			}
+			symlinks = append(symlinks, pendingSymlink{name: header.Name, target: header.Linkname})
+			entryTypes[header.Name] = tar.TypeSymlink
+		default:
+			return fmt.Errorf("root filesystem entry %q has unsupported type %d", header.Name, header.Typeflag)
+		}
+	}
+	if err := canonicalWriter.Close(); err != nil {
+		return fmt.Errorf("finish canonical root filesystem: %w", err)
+	}
+	if !bytes.Equal(originalDigest.Sum(nil), canonicalDigest.Sum(nil)) {
+		return errors.New("root filesystem component is not canonical rootfs-pax-tar/v1")
+	}
+	for _, symlink := range symlinks {
+		if err := root.Symlink(symlink.target, symlink.name); err != nil {
+			return fmt.Errorf("create root filesystem symlink %q: %w", symlink.name, err)
+		}
+	}
+	if err := validateInstalledEntrypoint(root, entrypoint); err != nil {
+		return err
+	}
+	if err := makeDirectoriesReadOnly(root, directories); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateInstalledEntrypoint(root *os.Root, entrypoint string) error {
+	current := strings.TrimPrefix(entrypoint, "/")
+	for range 40 {
+		if err := validateRelativePath(current); err != nil {
+			return fmt.Errorf("installed Python entrypoint %q is unsafe: %w", entrypoint, err)
+		}
+		info, err := root.Lstat(current)
+		if err != nil {
+			return fmt.Errorf("installed Python entrypoint %q is missing: %w", entrypoint, err)
+		}
+		if info.Mode().IsRegular() {
+			if info.Mode().Perm() != 0o555 {
+				return fmt.Errorf("installed Python entrypoint %q is not executable", entrypoint)
+			}
+			return nil
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			return fmt.Errorf("installed Python entrypoint %q does not resolve to a regular file", entrypoint)
+		}
+		target, err := root.Readlink(current)
+		if err != nil {
+			return fmt.Errorf("read installed Python entrypoint symlink %q: %w", current, err)
+		}
+		current = path.Clean(path.Join(path.Dir(current), target))
+	}
+	return fmt.Errorf("installed Python entrypoint %q has a symbolic-link cycle", entrypoint)
+}
+
+func ensureRootFSParents(root *os.Root, directory string, directories map[string]struct{}, entryTypes map[string]byte) error {
+	if directory == "." {
+		return nil
+	}
+	current := ""
+	for _, segment := range strings.Split(directory, "/") {
+		if current == "" {
+			current = segment
+		} else {
+			current = path.Join(current, segment)
+		}
+		if entryTypes[current] == tar.TypeSymlink {
+			return fmt.Errorf("root filesystem entry traverses symlink %q", current)
+		}
+		if _, exists := directories[current]; exists {
+			continue
+		}
+		if err := root.Mkdir(current, 0o700); err != nil {
+			return fmt.Errorf("create root filesystem directory %q: %w", current, err)
+		}
+		directories[current] = struct{}{}
+	}
+	return nil
+}
+
+func makeDirectoriesReadOnly(root *os.Root, directories map[string]struct{}) error {
+	names := make([]string, 0, len(directories))
+	for name := range directories {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		return strings.Count(names[i], "/") > strings.Count(names[j], "/")
+	})
+	for _, name := range names {
+		directory, err := root.Open(name)
+		if err != nil {
+			return fmt.Errorf("open root filesystem directory %q: %w", name, err)
+		}
+		if err := directory.Chmod(0o555); err != nil {
+			directory.Close()
+			return fmt.Errorf("make root filesystem directory %q read-only: %w", name, err)
+		}
+		if err := directory.Sync(); err != nil {
+			directory.Close()
+			return fmt.Errorf("sync root filesystem directory %q: %w", name, err)
+		}
+		if err := directory.Close(); err != nil {
+			return fmt.Errorf("close root filesystem directory %q: %w", name, err)
+		}
+	}
+	return nil
+}

--- a/internal/profilebundle/install_unsupported.go
+++ b/internal/profilebundle/install_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package profilebundle
+
+import "errors"
+
+func Install(InstallOptions) (string, error) {
+	return "", errors.New("root-owned Profile Bundle installation is supported only on Linux")
+}

--- a/internal/profilebundle/sync_directory_unix.go
+++ b/internal/profilebundle/sync_directory_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package profilebundle
+
+import (
+	"fmt"
+	"os"
+)
+
+func syncDirectory(directoryPath string) error {
+	directory, err := os.Open(directoryPath)
+	if err != nil {
+		return fmt.Errorf("open directory for sync: %w", err)
+	}
+	if err := directory.Sync(); err != nil {
+		directory.Close()
+		return fmt.Errorf("sync directory: %w", err)
+	}
+	if err := directory.Close(); err != nil {
+		return fmt.Errorf("close synced directory: %w", err)
+	}
+	return nil
+}

--- a/internal/profilebundle/sync_directory_windows.go
+++ b/internal/profilebundle/sync_directory_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package profilebundle
+
+func syncDirectory(string) error {
+	return nil
+}

--- a/internal/profilebundle/types.go
+++ b/internal/profilebundle/types.go
@@ -1,0 +1,105 @@
+// Package profilebundle builds and installs immutable Runtime Profile bundles.
+package profilebundle
+
+type BuildOptions struct {
+	LockPath             string
+	SourceCache          string
+	SystemCallPolicyPath string
+	SandboxInitPath      string
+	OutputPath           string
+}
+
+type InstallOptions struct {
+	BundlePath     string
+	ExpectedSHA256 string
+	StorePath      string
+}
+
+type buildLock struct {
+	Schema  string        `json:"schema"`
+	Profile string        `json:"profile"`
+	Target  target        `json:"target"`
+	Python  pythonRuntime `json:"python"`
+	Inputs  []lockedInput `json:"inputs"`
+}
+
+type target struct {
+	OS   string `json:"os"`
+	Arch string `json:"arch"`
+}
+
+type pythonRuntime struct {
+	Version    string          `json:"version"`
+	Entrypoint string          `json:"entrypoint"`
+	Packages   []lockedPackage `json:"packages"`
+}
+
+type lockedPackage struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Digest  string `json:"digest"`
+}
+
+type lockedInput struct {
+	ID            string   `json:"id"`
+	Kind          string   `json:"kind"`
+	Version       string   `json:"version"`
+	Source        string   `json:"source"`
+	Filename      string   `json:"filename"`
+	Size          int64    `json:"size"`
+	Digest        string   `json:"digest"`
+	ArchivePrefix string   `json:"archive_prefix"`
+	Destination   string   `json:"destination"`
+	Include       []string `json:"include"`
+	Exclude       []string `json:"exclude"`
+}
+
+type systemCallPolicy struct {
+	Schema        string                 `json:"schema"`
+	Profile       string                 `json:"profile"`
+	Target        target                 `json:"target"`
+	DefaultAction policyDefaultAction    `json:"default_action"`
+	Rules         []systemCallPolicyRule `json:"rules"`
+}
+
+type policyDefaultAction struct {
+	Action string `json:"action"`
+	Errno  int    `json:"errno"`
+}
+
+type systemCallPolicyRule struct {
+	Names     []string                   `json:"names"`
+	Action    string                     `json:"action"`
+	Arguments []systemCallPolicyArgument `json:"arguments"`
+}
+
+type systemCallPolicyArgument struct {
+	Index    uint   `json:"index"`
+	Operator string `json:"operator"`
+	Value    uint64 `json:"value"`
+	Mask     uint64 `json:"mask"`
+}
+
+type manifest struct {
+	Schema     string        `json:"schema"`
+	Profile    string        `json:"profile"`
+	Target     target        `json:"target"`
+	Python     pythonRuntime `json:"python"`
+	Components []component   `json:"components"`
+}
+
+type component struct {
+	Role   string `json:"role"`
+	Path   string `json:"path"`
+	Format string `json:"format"`
+	Mode   string `json:"mode"`
+	Size   int64  `json:"size"`
+	Digest string `json:"digest"`
+}
+
+var bundleV1Components = []component{
+	{Role: "build-lock", Path: "profile.lock.json", Format: "profile-build-lock/v1", Mode: "0444"},
+	{Role: "system-call-policy", Path: "system-call-policy.json", Format: "system-call-policy/v1", Mode: "0444"},
+	{Role: "sandbox-init", Path: "sandbox-init", Format: "opaque/v1", Mode: "0555"},
+	{Role: "rootfs", Path: "rootfs.tar", Format: "rootfs-pax-tar/v1", Mode: "0444"},
+}

--- a/profiles/python-data-v1/README.md
+++ b/profiles/python-data-v1/README.md
@@ -1,0 +1,18 @@
+# python-data-v1
+
+This directory contains the reviewed, version-controlled inputs for the first
+Runtime Profile.
+
+- `profile.lock.json` pins every external root-filesystem input by version,
+  immutable source URL, size, and SHA-256.
+- `system-call-policy.json` is the digest-bound, default-deny candidate System
+  Call Policy. T08 must add and verify the reviewed rules before production
+  Workload execution.
+
+The profile targets `linux/amd64`, provides CPython 3.14.7 and standard-library
+data modules, and intentionally contains no third-party Python packages. The
+builder removes package-installation tooling and consumes only a preverified
+source cache; it never downloads dependencies itself.
+
+See [Profile Bundle v1](../../docs/profile-bundle-v1.md) for the public format,
+build, installation, and trust contracts.

--- a/profiles/python-data-v1/profile.lock.json
+++ b/profiles/python-data-v1/profile.lock.json
@@ -1,0 +1,51 @@
+{
+  "schema": "profile-build-lock/v1",
+  "profile": "python-data-v1",
+  "target": {
+    "os": "linux",
+    "arch": "amd64"
+  },
+  "python": {
+    "version": "3.14.7",
+    "entrypoint": "/opt/python/bin/python3",
+    "packages": []
+  },
+  "inputs": [
+    {
+      "id": "musl-runtime-loader",
+      "kind": "rootfs-overlay",
+      "version": "alpine-3.22.5-musl-1.2.5-r12",
+      "source": "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/x86_64/alpine-minirootfs-3.22.5-x86_64.tar.gz",
+      "filename": "alpine-minirootfs-3.22.5-x86_64.tar.gz",
+      "size": 3638276,
+      "digest": "sha256:4b4daa9fe2fc696c4919c4412a4c3d3e770d8fb70292a004a2c72f5096175282",
+      "archive_prefix": "",
+      "destination": "",
+      "include": [
+        "lib/ld-musl-x86_64.so.1"
+      ],
+      "exclude": []
+    },
+    {
+      "id": "python-runtime",
+      "kind": "python-install-only",
+      "version": "3.14.7+20260825",
+      "source": "https://github.com/astral-sh/python-build-standalone/releases/download/20260825/cpython-3.14.7%2B20260825-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
+      "filename": "cpython-3.14.7+20260825-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
+      "size": 29011055,
+      "digest": "sha256:22374158b61f9415135614fb7ebdba498a84849921bb5ad025809e925d8bb428",
+      "archive_prefix": "python/",
+      "destination": "opt/python/",
+      "include": [],
+      "exclude": [
+        "bin/pip",
+        "bin/pip3",
+        "bin/pip3.14",
+        "lib/python3.14/ensurepip",
+        "lib/python3.14/site-packages/pip",
+        "lib/python3.14/site-packages/pip-26.2.1.dist-info",
+        "share/terminfo"
+      ]
+    }
+  ]
+}

--- a/profiles/python-data-v1/system-call-policy.json
+++ b/profiles/python-data-v1/system-call-policy.json
@@ -1,0 +1,13 @@
+{
+  "schema": "system-call-policy/v1",
+  "profile": "python-data-v1",
+  "target": {
+    "os": "linux",
+    "arch": "amd64"
+  },
+  "default_action": {
+    "action": "errno",
+    "errno": 1
+  },
+  "rules": []
+}

--- a/tests/profile_bundle_cli_test.go
+++ b/tests/profile_bundle_cli_test.go
@@ -1,0 +1,750 @@
+package workspace_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestProfileBundleBuildRecordsSuppliedSandboxInitIdentity(t *testing.T) {
+	repositoryRoot := profileBundleRepositoryRoot(t)
+	temporaryDirectory := t.TempDir()
+	sourceCache := filepath.Join(temporaryDirectory, "source-cache")
+	if err := os.Mkdir(sourceCache, 0o755); err != nil {
+		t.Fatal("create source cache:", err)
+	}
+
+	sourceArchive := filepath.Join(sourceCache, "python-runtime.tar.gz")
+	writePythonSourceArchive(t, sourceArchive)
+	sourceDigest := fileSHA256(t, sourceArchive)
+	sourceInfo, err := os.Stat(sourceArchive)
+	if err != nil {
+		t.Fatal("stat source archive:", err)
+	}
+
+	lockPath := filepath.Join(temporaryDirectory, "profile.lock.json")
+	lock := fmt.Sprintf(`{
+  "schema": "profile-build-lock/v1",
+  "profile": "python-data-v1",
+  "target": {"os": "linux", "arch": "amd64"},
+  "python": {"version": "3.14.7", "entrypoint": "/opt/python/bin/python3", "packages": []},
+  "inputs": [{
+    "id": "python-runtime",
+    "kind": "python-install-only",
+    "version": "3.14.7+test",
+    "source": "https://example.invalid/python-runtime.tar.gz",
+    "filename": "python-runtime.tar.gz",
+    "size": %d,
+    "digest": "sha256:%s",
+    "archive_prefix": "python/",
+    "destination": "opt/python/",
+    "include": [],
+    "exclude": []
+  }]
+}
+`, sourceInfo.Size(), sourceDigest)
+	if err := os.WriteFile(lockPath, []byte(lock), 0o644); err != nil {
+		t.Fatal("write build lock:", err)
+	}
+
+	policyPath := filepath.Join(temporaryDirectory, "system-call-policy.json")
+	policy := []byte("{\"schema\":\"system-call-policy/v1\",\"profile\":\"python-data-v1\",\"target\":{\"os\":\"linux\",\"arch\":\"amd64\"},\"default_action\":{\"action\":\"errno\",\"errno\":1},\"rules\":[]}\n")
+	if err := os.WriteFile(policyPath, policy, 0o644); err != nil {
+		t.Fatal("write System Call Policy:", err)
+	}
+
+	initPath := filepath.Join(temporaryDirectory, "sandbox-init")
+	if err := os.WriteFile(initPath, []byte("abc"), 0o755); err != nil {
+		t.Fatal("write Sandbox Init:", err)
+	}
+
+	bundlePath := filepath.Join(temporaryDirectory, "python-data-v1.bundle")
+	command := exec.Command(
+		"go", "run", "./cmd/profile-bundle", "build",
+		"--lock", lockPath,
+		"--source-cache", sourceCache,
+		"--system-call-policy", policyPath,
+		"--sandbox-init", initPath,
+		"--output", bundlePath,
+	)
+	command.Dir = repositoryRoot
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("build Profile Bundle: %v\n%s", err, output)
+	}
+
+	entries := readOuterBundle(t, bundlePath)
+	manifestBytes, ok := entries["manifest.json"]
+	if !ok {
+		t.Fatal("built Profile Bundle has no manifest.json")
+	}
+
+	var manifest struct {
+		Components []struct {
+			Role   string `json:"role"`
+			Digest string `json:"digest"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		t.Fatal("decode public Profile Bundle manifest:", err)
+	}
+
+	const expectedInitDigest = "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+	for _, component := range manifest.Components {
+		if component.Role == "sandbox-init" {
+			if component.Digest != expectedInitDigest {
+				t.Fatalf("Sandbox Init digest = %q, want %q", component.Digest, expectedInitDigest)
+			}
+			return
+		}
+	}
+
+	t.Fatal("public Profile Bundle manifest does not declare the Sandbox Init component")
+}
+
+func TestPythonDataV1RecipePinsEveryExternalInput(t *testing.T) {
+	repositoryRoot := profileBundleRepositoryRoot(t)
+	lockPath := filepath.Join(repositoryRoot, "profiles", "python-data-v1", "profile.lock.json")
+	lockBytes, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatal("read published python-data-v1 build lock:", err)
+	}
+
+	var lock struct {
+		Schema  string `json:"schema"`
+		Profile string `json:"profile"`
+		Target  struct {
+			OS   string `json:"os"`
+			Arch string `json:"arch"`
+		} `json:"target"`
+		Python struct {
+			Version  string `json:"version"`
+			Packages []any  `json:"packages"`
+		} `json:"python"`
+		Inputs []struct {
+			Version  string `json:"version"`
+			Source   string `json:"source"`
+			Filename string `json:"filename"`
+			Size     int64  `json:"size"`
+			Digest   string `json:"digest"`
+		} `json:"inputs"`
+	}
+	if err := json.Unmarshal(lockBytes, &lock); err != nil {
+		t.Fatal("decode published python-data-v1 build lock:", err)
+	}
+
+	wantHeader := struct {
+		Schema        string
+		Profile       string
+		TargetOS      string
+		TargetArch    string
+		PythonVersion string
+	}{
+		Schema:        "profile-build-lock/v1",
+		Profile:       "python-data-v1",
+		TargetOS:      "linux",
+		TargetArch:    "amd64",
+		PythonVersion: "3.14.7",
+	}
+	gotHeader := struct {
+		Schema        string
+		Profile       string
+		TargetOS      string
+		TargetArch    string
+		PythonVersion string
+	}{
+		Schema:        lock.Schema,
+		Profile:       lock.Profile,
+		TargetOS:      lock.Target.OS,
+		TargetArch:    lock.Target.Arch,
+		PythonVersion: lock.Python.Version,
+	}
+	if gotHeader != wantHeader {
+		t.Fatalf("published python-data-v1 lock header = %#v, want %#v", gotHeader, wantHeader)
+	}
+	wantInputs := []struct {
+		Version  string
+		Source   string
+		Filename string
+		Size     int64
+		Digest   string
+	}{
+		{
+			Version:  "alpine-3.22.5-musl-1.2.5-r12",
+			Source:   "https://dl-cdn.alpinelinux.org/alpine/v3.22/releases/x86_64/alpine-minirootfs-3.22.5-x86_64.tar.gz",
+			Filename: "alpine-minirootfs-3.22.5-x86_64.tar.gz",
+			Size:     3638276,
+			Digest:   "sha256:4b4daa9fe2fc696c4919c4412a4c3d3e770d8fb70292a004a2c72f5096175282",
+		},
+		{
+			Version:  "3.14.7+20260825",
+			Source:   "https://github.com/astral-sh/python-build-standalone/releases/download/20260825/cpython-3.14.7%2B20260825-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
+			Filename: "cpython-3.14.7+20260825-x86_64-unknown-linux-musl-install_only_stripped.tar.gz",
+			Size:     29011055,
+			Digest:   "sha256:22374158b61f9415135614fb7ebdba498a84849921bb5ad025809e925d8bb428",
+		},
+	}
+	if len(lock.Inputs) != len(wantInputs) {
+		t.Fatalf("published python-data-v1 inputs = %d, want %d", len(lock.Inputs), len(wantInputs))
+	}
+	for index, want := range wantInputs {
+		got := lock.Inputs[index]
+		if got.Version != want.Version || got.Source != want.Source || got.Filename != want.Filename || got.Size != want.Size || got.Digest != want.Digest {
+			t.Fatalf("published python-data-v1 input %d = %#v, want %#v", index, got, want)
+		}
+	}
+	if len(lock.Python.Packages) != 0 {
+		t.Fatalf("python-data-v1 unexpectedly declares third-party packages: %#v", lock.Python.Packages)
+	}
+}
+
+func TestPythonDataV1SystemCallPolicyDefaultsToDeny(t *testing.T) {
+	repositoryRoot := profileBundleRepositoryRoot(t)
+	policyPath := filepath.Join(repositoryRoot, "profiles", "python-data-v1", "system-call-policy.json")
+	policyBytes, err := os.ReadFile(policyPath)
+	if err != nil {
+		t.Fatal("read published python-data-v1 System Call Policy:", err)
+	}
+
+	var policy struct {
+		Schema  string `json:"schema"`
+		Profile string `json:"profile"`
+		Target  struct {
+			OS   string `json:"os"`
+			Arch string `json:"arch"`
+		} `json:"target"`
+		DefaultAction struct {
+			Action string `json:"action"`
+			Errno  int    `json:"errno"`
+		} `json:"default_action"`
+	}
+	if err := json.Unmarshal(policyBytes, &policy); err != nil {
+		t.Fatal("decode published python-data-v1 System Call Policy:", err)
+	}
+
+	if policy.Schema != "system-call-policy/v1" ||
+		policy.Profile != "python-data-v1" ||
+		policy.Target.OS != "linux" ||
+		policy.Target.Arch != "amd64" ||
+		policy.DefaultAction.Action != "errno" ||
+		policy.DefaultAction.Errno != 1 {
+		t.Fatalf("python-data-v1 policy does not provide the published default-deny contract: %#v", policy)
+	}
+}
+
+func TestProfileBundleBuildCanonicalizesRootFilesystemOrder(t *testing.T) {
+	repositoryRoot := profileBundleRepositoryRoot(t)
+	temporaryDirectory := t.TempDir()
+	sourceCache := filepath.Join(temporaryDirectory, "source-cache")
+	if err := os.Mkdir(sourceCache, 0o755); err != nil {
+		t.Fatal("create source cache:", err)
+	}
+	sourceArchive := filepath.Join(sourceCache, "python-runtime.tar.gz")
+	writeReverseOrderedPythonSourceArchive(t, sourceArchive)
+	sourceInfo, err := os.Stat(sourceArchive)
+	if err != nil {
+		t.Fatal("stat source archive:", err)
+	}
+
+	lockPath := filepath.Join(temporaryDirectory, "profile.lock.json")
+	lock := fmt.Sprintf(`{"schema":"profile-build-lock/v1","profile":"python-data-v1","target":{"os":"linux","arch":"amd64"},"python":{"version":"3.14.7","entrypoint":"/opt/python/bin/python3","packages":[]},"inputs":[{"id":"python-runtime","kind":"python-install-only","version":"3.14.7+test","source":"https://example.invalid/python-runtime.tar.gz","filename":"python-runtime.tar.gz","size":%d,"digest":"sha256:%s","archive_prefix":"python/","destination":"opt/python/","include":[],"exclude":[]}]}
+`, sourceInfo.Size(), fileSHA256(t, sourceArchive))
+	if err := os.WriteFile(lockPath, []byte(lock), 0o644); err != nil {
+		t.Fatal("write build lock:", err)
+	}
+	policyPath := filepath.Join(temporaryDirectory, "system-call-policy.json")
+	policy := []byte("{\"schema\":\"system-call-policy/v1\",\"profile\":\"python-data-v1\",\"target\":{\"os\":\"linux\",\"arch\":\"amd64\"},\"default_action\":{\"action\":\"errno\",\"errno\":1},\"rules\":[]}\n")
+	if err := os.WriteFile(policyPath, policy, 0o644); err != nil {
+		t.Fatal("write System Call Policy:", err)
+	}
+	initPath := filepath.Join(temporaryDirectory, "sandbox-init")
+	if err := os.WriteFile(initPath, []byte("abc"), 0o755); err != nil {
+		t.Fatal("write Sandbox Init:", err)
+	}
+	bundlePath := filepath.Join(temporaryDirectory, "python-data-v1.bundle")
+	command := exec.Command(
+		"go", "run", "./cmd/profile-bundle", "build",
+		"--lock", lockPath,
+		"--source-cache", sourceCache,
+		"--system-call-policy", policyPath,
+		"--sandbox-init", initPath,
+		"--output", bundlePath,
+	)
+	command.Dir = repositoryRoot
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("build Profile Bundle from reverse-ordered source: %v\n%s", err, output)
+	}
+
+	rootfs := readOuterBundle(t, bundlePath)["rootfs.tar"]
+	reader := tar.NewReader(bytes.NewReader(rootfs))
+	var names []string
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal("read canonical root filesystem:", err)
+		}
+		names = append(names, header.Name)
+	}
+	want := []string{"opt/python/bin/a-helper", "opt/python/bin/python3"}
+	if len(names) != len(want) || names[0] != want[0] || names[1] != want[1] {
+		t.Fatalf("canonical root filesystem order = %#v, want %#v", names, want)
+	}
+}
+
+func TestProfileBundleBuildRejectsMismatchedSystemCallPolicy(t *testing.T) {
+	repositoryRoot := profileBundleRepositoryRoot(t)
+	temporaryDirectory := t.TempDir()
+	sourceCache := filepath.Join(temporaryDirectory, "source-cache")
+	if err := os.Mkdir(sourceCache, 0o755); err != nil {
+		t.Fatal("create source cache:", err)
+	}
+	sourceArchive := filepath.Join(sourceCache, "python-runtime.tar.gz")
+	writePythonSourceArchive(t, sourceArchive)
+	sourceInfo, err := os.Stat(sourceArchive)
+	if err != nil {
+		t.Fatal("stat source archive:", err)
+	}
+	lockPath := filepath.Join(temporaryDirectory, "profile.lock.json")
+	lock := fmt.Sprintf(`{"schema":"profile-build-lock/v1","profile":"python-data-v1","target":{"os":"linux","arch":"amd64"},"python":{"version":"3.14.7","entrypoint":"/opt/python/bin/python3","packages":[]},"inputs":[{"id":"python-runtime","kind":"python-install-only","version":"3.14.7+test","source":"https://example.invalid/python-runtime.tar.gz","filename":"python-runtime.tar.gz","size":%d,"digest":"sha256:%s","archive_prefix":"python/","destination":"opt/python/","include":[],"exclude":[]}]}
+`, sourceInfo.Size(), fileSHA256(t, sourceArchive))
+	if err := os.WriteFile(lockPath, []byte(lock), 0o644); err != nil {
+		t.Fatal("write build lock:", err)
+	}
+	policyPath := filepath.Join(temporaryDirectory, "system-call-policy.json")
+	mismatchedPolicy := []byte("{\"schema\":\"system-call-policy/v1\",\"profile\":\"another-profile\",\"target\":{\"os\":\"linux\",\"arch\":\"amd64\"},\"default_action\":{\"action\":\"errno\",\"errno\":1},\"rules\":[]}\n")
+	if err := os.WriteFile(policyPath, mismatchedPolicy, 0o644); err != nil {
+		t.Fatal("write mismatched System Call Policy:", err)
+	}
+	initPath := filepath.Join(temporaryDirectory, "sandbox-init")
+	if err := os.WriteFile(initPath, []byte("abc"), 0o755); err != nil {
+		t.Fatal("write Sandbox Init:", err)
+	}
+	bundlePath := filepath.Join(temporaryDirectory, "python-data-v1.bundle")
+	command := exec.Command(
+		"go", "run", "./cmd/profile-bundle", "build",
+		"--lock", lockPath,
+		"--source-cache", sourceCache,
+		"--system-call-policy", policyPath,
+		"--sandbox-init", initPath,
+		"--output", bundlePath,
+	)
+	command.Dir = repositoryRoot
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("build accepted a System Call Policy for another profile:\n%s", output)
+	}
+}
+
+func TestProfileBundleBuildRejectsMalformedSystemCallPolicyRule(t *testing.T) {
+	repositoryRoot := profileBundleRepositoryRoot(t)
+	temporaryDirectory := t.TempDir()
+	policyPath := filepath.Join(temporaryDirectory, "system-call-policy.json")
+	malformedPolicy := []byte("{\"schema\":\"system-call-policy/v1\",\"profile\":\"python-data-v1\",\"target\":{\"os\":\"linux\",\"arch\":\"amd64\"},\"default_action\":{\"action\":\"errno\",\"errno\":1},\"rules\":[{\"names\":[\"../bad\"],\"action\":\"allow\",\"arguments\":null}]}\n")
+	if err := os.WriteFile(policyPath, malformedPolicy, 0o644); err != nil {
+		t.Fatal("write malformed System Call Policy:", err)
+	}
+	initPath := filepath.Join(temporaryDirectory, "sandbox-init")
+	if err := os.WriteFile(initPath, []byte("abc"), 0o755); err != nil {
+		t.Fatal("write Sandbox Init:", err)
+	}
+	sourceCache := filepath.Join(temporaryDirectory, "source-cache")
+	if err := os.Mkdir(sourceCache, 0o755); err != nil {
+		t.Fatal("create empty source cache:", err)
+	}
+	command := exec.Command(
+		"go", "run", "./cmd/profile-bundle", "build",
+		"--lock", filepath.Join(repositoryRoot, "profiles", "python-data-v1", "profile.lock.json"),
+		"--source-cache", sourceCache,
+		"--system-call-policy", policyPath,
+		"--sandbox-init", initPath,
+		"--output", filepath.Join(temporaryDirectory, "malformed-policy.bundle"),
+	)
+	command.Dir = repositoryRoot
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("build accepted a malformed System Call Policy rule:\n%s", output)
+	}
+}
+
+func TestProfileBundleBuildDoesNotOverwriteConcurrentOutput(t *testing.T) {
+	repositoryRoot := profileBundleRepositoryRoot(t)
+	temporaryDirectory := t.TempDir()
+	sourceCache := filepath.Join(temporaryDirectory, "source-cache")
+	if err := os.Mkdir(sourceCache, 0o755); err != nil {
+		t.Fatal("create source cache:", err)
+	}
+	sourceArchive := filepath.Join(sourceCache, "python-runtime.tar.gz")
+	writePythonSourceArchive(t, sourceArchive)
+	sourceInfo, err := os.Stat(sourceArchive)
+	if err != nil {
+		t.Fatal("stat source archive:", err)
+	}
+	lockPath := filepath.Join(temporaryDirectory, "profile.lock.json")
+	lock := fmt.Sprintf(`{"schema":"profile-build-lock/v1","profile":"python-data-v1","target":{"os":"linux","arch":"amd64"},"python":{"version":"3.14.7","entrypoint":"/opt/python/bin/python3","packages":[]},"inputs":[{"id":"python-runtime","kind":"python-install-only","version":"3.14.7+test","source":"https://example.invalid/python-runtime.tar.gz","filename":"python-runtime.tar.gz","size":%d,"digest":"sha256:%s","archive_prefix":"python/","destination":"opt/python/","include":[],"exclude":[]}]}
+`, sourceInfo.Size(), fileSHA256(t, sourceArchive))
+	if err := os.WriteFile(lockPath, []byte(lock), 0o644); err != nil {
+		t.Fatal("write build lock:", err)
+	}
+	policyPath := filepath.Join(temporaryDirectory, "system-call-policy.json")
+	if err := os.WriteFile(policyPath, validCLIFixturePolicy(), 0o644); err != nil {
+		t.Fatal("write System Call Policy:", err)
+	}
+	initPaths := []string{
+		filepath.Join(temporaryDirectory, "sandbox-init-one"),
+		filepath.Join(temporaryDirectory, "sandbox-init-two"),
+	}
+	if err := os.WriteFile(initPaths[0], []byte("abc"), 0o755); err != nil {
+		t.Fatal("write first Sandbox Init:", err)
+	}
+	if err := os.WriteFile(initPaths[1], []byte("abcd"), 0o755); err != nil {
+		t.Fatal("write second Sandbox Init:", err)
+	}
+	outputPath := filepath.Join(temporaryDirectory, "concurrent.bundle")
+
+	commands := make([]*exec.Cmd, len(initPaths))
+	outputs := make([]bytes.Buffer, len(initPaths))
+	for index, initPath := range initPaths {
+		commands[index] = exec.Command(
+			"go", "run", "./cmd/profile-bundle", "build",
+			"--lock", lockPath,
+			"--source-cache", sourceCache,
+			"--system-call-policy", policyPath,
+			"--sandbox-init", initPath,
+			"--output", outputPath,
+		)
+		commands[index].Dir = repositoryRoot
+		commands[index].Stdout = &outputs[index]
+		commands[index].Stderr = &outputs[index]
+		if err := commands[index].Start(); err != nil {
+			t.Fatalf("start concurrent build %d: %v", index+1, err)
+		}
+	}
+	successes := 0
+	winnerDigest := ""
+	for index, command := range commands {
+		if err := command.Wait(); err == nil {
+			successes++
+			winnerDigest = strings.TrimSpace(outputs[index].String())
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("concurrent builds succeeded %d times, want exactly one; outputs=%v", successes, outputs)
+	}
+	if actualDigest := fileSHA256(t, outputPath); actualDigest != winnerDigest {
+		t.Fatalf("published concurrent Bundle SHA-256 = %q, successful builder reported %q", actualDigest, winnerDigest)
+	}
+}
+
+func TestProfileBundleBuildRejectsRootFilesystemWhoseImplicitDirectoriesExceedBudget(t *testing.T) {
+	repositoryRoot := profileBundleRepositoryRoot(t)
+	temporaryDirectory := t.TempDir()
+	sourceCache := filepath.Join(temporaryDirectory, "source-cache")
+	if err := os.Mkdir(sourceCache, 0o755); err != nil {
+		t.Fatal("create source cache:", err)
+	}
+	sourceArchive := filepath.Join(sourceCache, "python-runtime.tar.gz")
+	writeDeepPythonSourceArchive(t, sourceArchive)
+	sourceInfo, err := os.Stat(sourceArchive)
+	if err != nil {
+		t.Fatal("stat deep source archive:", err)
+	}
+	lockPath := filepath.Join(temporaryDirectory, "profile.lock.json")
+	lock := fmt.Sprintf(`{"schema":"profile-build-lock/v1","profile":"python-data-v1","target":{"os":"linux","arch":"amd64"},"python":{"version":"3.14.7","entrypoint":"/opt/python/bin/python3","packages":[]},"inputs":[{"id":"python-runtime","kind":"python-install-only","version":"3.14.7+test","source":"https://example.invalid/python-runtime.tar.gz","filename":"python-runtime.tar.gz","size":%d,"digest":"sha256:%s","archive_prefix":"python/","destination":"opt/python/","include":[],"exclude":[]}]}
+`, sourceInfo.Size(), fileSHA256(t, sourceArchive))
+	if err := os.WriteFile(lockPath, []byte(lock), 0o644); err != nil {
+		t.Fatal("write build lock:", err)
+	}
+	policyPath := filepath.Join(temporaryDirectory, "system-call-policy.json")
+	if err := os.WriteFile(policyPath, validCLIFixturePolicy(), 0o644); err != nil {
+		t.Fatal("write System Call Policy:", err)
+	}
+	initPath := filepath.Join(temporaryDirectory, "sandbox-init")
+	if err := os.WriteFile(initPath, []byte("abc"), 0o755); err != nil {
+		t.Fatal("write Sandbox Init:", err)
+	}
+	command := exec.Command(
+		"go", "run", "./cmd/profile-bundle", "build",
+		"--lock", lockPath,
+		"--source-cache", sourceCache,
+		"--system-call-policy", policyPath,
+		"--sandbox-init", initPath,
+		"--output", filepath.Join(temporaryDirectory, "over-budget.bundle"),
+	)
+	command.Dir = repositoryRoot
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("build accepted a root filesystem whose implicit directories exceed the v1 budget:\n%s", output)
+	}
+}
+
+func TestProfileBundleBuildRejectsNonDirectoryAncestor(t *testing.T) {
+	repositoryRoot := profileBundleRepositoryRoot(t)
+	temporaryDirectory := t.TempDir()
+	sourceCache := filepath.Join(temporaryDirectory, "source-cache")
+	if err := os.Mkdir(sourceCache, 0o755); err != nil {
+		t.Fatal("create source cache:", err)
+	}
+	sourceArchive := filepath.Join(sourceCache, "python-runtime.tar.gz")
+	writeConflictingPythonSourceArchive(t, sourceArchive)
+	sourceInfo, err := os.Stat(sourceArchive)
+	if err != nil {
+		t.Fatal("stat conflicting source archive:", err)
+	}
+	lockPath := filepath.Join(temporaryDirectory, "profile.lock.json")
+	lock := fmt.Sprintf(`{"schema":"profile-build-lock/v1","profile":"python-data-v1","target":{"os":"linux","arch":"amd64"},"python":{"version":"3.14.7","entrypoint":"/opt/python/bin/python3","packages":[]},"inputs":[{"id":"python-runtime","kind":"python-install-only","version":"3.14.7+test","source":"https://example.invalid/python-runtime.tar.gz","filename":"python-runtime.tar.gz","size":%d,"digest":"sha256:%s","archive_prefix":"python/","destination":"opt/python/","include":[],"exclude":[]}]}
+`, sourceInfo.Size(), fileSHA256(t, sourceArchive))
+	if err := os.WriteFile(lockPath, []byte(lock), 0o644); err != nil {
+		t.Fatal("write build lock:", err)
+	}
+	policyPath := filepath.Join(temporaryDirectory, "system-call-policy.json")
+	if err := os.WriteFile(policyPath, validCLIFixturePolicy(), 0o644); err != nil {
+		t.Fatal("write System Call Policy:", err)
+	}
+	initPath := filepath.Join(temporaryDirectory, "sandbox-init")
+	if err := os.WriteFile(initPath, []byte("abc"), 0o755); err != nil {
+		t.Fatal("write Sandbox Init:", err)
+	}
+	command := exec.Command(
+		"go", "run", "./cmd/profile-bundle", "build",
+		"--lock", lockPath,
+		"--source-cache", sourceCache,
+		"--system-call-policy", policyPath,
+		"--sandbox-init", initPath,
+		"--output", filepath.Join(temporaryDirectory, "conflicting-tree.bundle"),
+	)
+	command.Dir = repositoryRoot
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("build accepted a regular file as another rootfs entry's parent:\n%s", output)
+	}
+}
+
+func validCLIFixturePolicy() []byte {
+	return []byte("{\"schema\":\"system-call-policy/v1\",\"profile\":\"python-data-v1\",\"target\":{\"os\":\"linux\",\"arch\":\"amd64\"},\"default_action\":{\"action\":\"errno\",\"errno\":1},\"rules\":[]}\n")
+}
+
+func writePythonSourceArchive(t *testing.T, archivePath string) {
+	t.Helper()
+
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal("create Python source archive:", err)
+	}
+	gzipWriter := gzip.NewWriter(file)
+	gzipWriter.Header.ModTime = time.Unix(0, 0).UTC()
+	gzipWriter.Header.OS = 255
+	tarWriter := tar.NewWriter(gzipWriter)
+
+	contents := []byte("fixture-python")
+	header := &tar.Header{
+		Name:     "python/bin/python3",
+		Mode:     0o755,
+		Size:     int64(len(contents)),
+		Typeflag: tar.TypeReg,
+		ModTime:  time.Unix(0, 0).UTC(),
+		Format:   tar.FormatPAX,
+	}
+	if err := tarWriter.WriteHeader(header); err != nil {
+		t.Fatal("write Python source header:", err)
+	}
+	if _, err := tarWriter.Write(contents); err != nil {
+		t.Fatal("write Python source contents:", err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal("close Python source tar:", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal("close Python source gzip:", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal("close Python source archive:", err)
+	}
+}
+
+func writeReverseOrderedPythonSourceArchive(t *testing.T, archivePath string) {
+	t.Helper()
+
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal("create reverse-ordered Python source archive:", err)
+	}
+	gzipWriter := gzip.NewWriter(file)
+	gzipWriter.Header.ModTime = time.Unix(0, 0).UTC()
+	gzipWriter.Header.OS = 255
+	tarWriter := tar.NewWriter(gzipWriter)
+	for _, entry := range []struct {
+		name     string
+		contents string
+	}{
+		{name: "python/bin/python3", contents: "fixture-python"},
+		{name: "python/bin/a-helper", contents: "helper"},
+	} {
+		header := &tar.Header{
+			Name:     entry.name,
+			Mode:     0o755,
+			Size:     int64(len(entry.contents)),
+			Typeflag: tar.TypeReg,
+			ModTime:  time.Unix(0, 0).UTC(),
+			Format:   tar.FormatPAX,
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			t.Fatalf("write reverse-ordered source header %q: %v", entry.name, err)
+		}
+		if _, err := tarWriter.Write([]byte(entry.contents)); err != nil {
+			t.Fatalf("write reverse-ordered source contents %q: %v", entry.name, err)
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal("close reverse-ordered source tar:", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal("close reverse-ordered source gzip:", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal("close reverse-ordered source archive:", err)
+	}
+}
+
+func writeDeepPythonSourceArchive(t *testing.T, archivePath string) {
+	t.Helper()
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal("create deep Python source archive:", err)
+	}
+	gzipWriter := gzip.NewWriter(file)
+	gzipWriter.Header.ModTime = time.Unix(0, 0).UTC()
+	gzipWriter.Header.OS = 255
+	tarWriter := tar.NewWriter(gzipWriter)
+	writeEntry := func(name string) {
+		contents := []byte("x")
+		header := &tar.Header{
+			Name:     name,
+			Mode:     0o755,
+			Size:     int64(len(contents)),
+			Typeflag: tar.TypeReg,
+			ModTime:  time.Unix(0, 0).UTC(),
+			Format:   tar.FormatPAX,
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			t.Fatalf("write deep source header %q: %v", name, err)
+		}
+		if _, err := tarWriter.Write(contents); err != nil {
+			t.Fatalf("write deep source contents %q: %v", name, err)
+		}
+	}
+	writeEntry("python/bin/python3")
+	deepSegments := strings.Repeat("a/", 1960)
+	for index := range 51 {
+		writeEntry(fmt.Sprintf("python/deep-%02d/%sfile", index, deepSegments))
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal("close deep source tar:", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal("close deep source gzip:", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal("close deep source archive:", err)
+	}
+}
+
+func writeConflictingPythonSourceArchive(t *testing.T, archivePath string) {
+	t.Helper()
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal("create conflicting Python source archive:", err)
+	}
+	gzipWriter := gzip.NewWriter(file)
+	gzipWriter.Header.ModTime = time.Unix(0, 0).UTC()
+	gzipWriter.Header.OS = 255
+	tarWriter := tar.NewWriter(gzipWriter)
+	for _, name := range []string{"python/a", "python/a/b", "python/bin/python3"} {
+		contents := []byte("x")
+		header := &tar.Header{
+			Name:     name,
+			Mode:     0o755,
+			Size:     int64(len(contents)),
+			Typeflag: tar.TypeReg,
+			ModTime:  time.Unix(0, 0).UTC(),
+			Format:   tar.FormatPAX,
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			t.Fatalf("write conflicting source header %q: %v", name, err)
+		}
+		if _, err := tarWriter.Write(contents); err != nil {
+			t.Fatalf("write conflicting source contents %q: %v", name, err)
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatal("close conflicting source tar:", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatal("close conflicting source gzip:", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal("close conflicting source archive:", err)
+	}
+}
+
+func fileSHA256(t *testing.T, path string) string {
+	t.Helper()
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal("open file for SHA-256:", err)
+	}
+	defer file.Close()
+
+	digest := sha256.New()
+	if _, err := io.Copy(digest, file); err != nil {
+		t.Fatal("calculate SHA-256:", err)
+	}
+	return hex.EncodeToString(digest.Sum(nil))
+}
+
+func readOuterBundle(t *testing.T, bundlePath string) map[string][]byte {
+	t.Helper()
+
+	file, err := os.Open(bundlePath)
+	if err != nil {
+		t.Fatal("open Profile Bundle:", err)
+	}
+	defer file.Close()
+
+	entries := make(map[string][]byte)
+	reader := tar.NewReader(file)
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			return entries
+		}
+		if err != nil {
+			t.Fatal("read Profile Bundle:", err)
+		}
+		contents, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatalf("read Profile Bundle entry %q: %v", header.Name, err)
+		}
+		entries[header.Name] = contents
+	}
+}
+
+func profileBundleRepositoryRoot(t *testing.T) string {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate Profile Bundle integration test")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), ".."))
+}

--- a/tests/profile_bundle_install_linux_test.go
+++ b/tests/profile_bundle_install_linux_test.go
@@ -1,0 +1,728 @@
+//go:build linux && profilebundle_root
+
+package workspace_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestProfileBundleInstallPublishesVerifiedRootOwnedProfile(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Fatal("profilebundle_root tests must run as root on a disposable Linux environment")
+	}
+	cliPath := os.Getenv("PROFILE_BUNDLE_CLI")
+	if cliPath == "" {
+		t.Fatal("PROFILE_BUNDLE_CLI must name the prebuilt profile-bundle command")
+	}
+
+	temporaryDirectory := t.TempDir()
+	if err := os.Chmod(temporaryDirectory, 0o755); err != nil {
+		t.Fatal("make test parent traversable by the non-privileged probe:", err)
+	}
+	bundlePath := filepath.Join(temporaryDirectory, "fixture.bundle")
+	bundleDigest := writeIndependentBundleFixture(t, bundlePath, validFixtureLock(), validFixturePolicy())
+	storePath := filepath.Join(temporaryDirectory, "profile-store")
+	if err := os.Mkdir(storePath, 0o755); err != nil {
+		t.Fatal("create Profile store:", err)
+	}
+
+	command := exec.Command(
+		cliPath, "install",
+		"--bundle", bundlePath,
+		"--expected-sha256", bundleDigest,
+		"--store", storePath,
+	)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("install valid Profile Bundle: %v\n%s", err, output)
+	}
+
+	installedPath := filepath.Join(storePath, "sha256", bundleDigest)
+	manifestPath := filepath.Join(installedPath, "manifest.json")
+	info, err := os.Stat(manifestPath)
+	if err != nil {
+		t.Fatal("stat installed manifest:", err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("installed manifest has no Linux ownership metadata")
+	}
+	if stat.Uid != 0 || stat.Gid != 0 {
+		t.Fatalf("installed manifest ownership = %d:%d, want 0:0", stat.Uid, stat.Gid)
+	}
+
+	writeAttempt := exec.Command(
+		"setpriv",
+		"--reuid=65534",
+		"--regid=65534",
+		"--clear-groups",
+		"sh", "-c", `printf tampered >> "$1"`, "sh", manifestPath,
+	)
+	if output, err := writeAttempt.CombinedOutput(); err == nil {
+		t.Fatalf("non-privileged process modified installed manifest:\n%s", output)
+	}
+}
+
+func TestProfileBundleInstallIsIdempotentForTheSameDigest(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Fatal("profilebundle_root tests must run as root on a disposable Linux environment")
+	}
+	cliPath := os.Getenv("PROFILE_BUNDLE_CLI")
+	if cliPath == "" {
+		t.Fatal("PROFILE_BUNDLE_CLI must name the prebuilt profile-bundle command")
+	}
+
+	temporaryDirectory := t.TempDir()
+	bundlePath := filepath.Join(temporaryDirectory, "fixture.bundle")
+	bundleDigest := writeIndependentBundleFixture(t, bundlePath, validFixtureLock(), validFixturePolicy())
+	storePath := filepath.Join(temporaryDirectory, "profile-store")
+	if err := os.Mkdir(storePath, 0o755); err != nil {
+		t.Fatal("create Profile store:", err)
+	}
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		command := exec.Command(
+			cliPath, "install",
+			"--bundle", bundlePath,
+			"--expected-sha256", bundleDigest,
+			"--store", storePath,
+		)
+		if output, err := command.CombinedOutput(); err != nil {
+			t.Fatalf("install identical Profile Bundle attempt %d: %v\n%s", attempt, err, output)
+		}
+	}
+
+	installed, err := os.ReadDir(filepath.Join(storePath, "sha256"))
+	if err != nil {
+		t.Fatal("list content-addressed Profile store:", err)
+	}
+	if len(installed) != 1 || installed[0].Name() != bundleDigest {
+		t.Fatalf("content-addressed Profile store entries = %#v, want only %q", installed, bundleDigest)
+	}
+}
+
+func TestProfileBundleInstallConcurrentlyPublishesOneIdenticalIdentity(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Fatal("profilebundle_root tests must run as root on a disposable Linux environment")
+	}
+	cliPath := os.Getenv("PROFILE_BUNDLE_CLI")
+	if cliPath == "" {
+		t.Fatal("PROFILE_BUNDLE_CLI must name the prebuilt profile-bundle command")
+	}
+	temporaryDirectory := t.TempDir()
+	bundlePath := filepath.Join(temporaryDirectory, "fixture.bundle")
+	bundleDigest := writeIndependentBundleFixture(t, bundlePath, validFixtureLock(), validFixturePolicy())
+	storePath := filepath.Join(temporaryDirectory, "profile-store")
+	if err := os.Mkdir(storePath, 0o755); err != nil {
+		t.Fatal("create Profile store:", err)
+	}
+
+	commands := make([]*exec.Cmd, 2)
+	outputs := make([]bytes.Buffer, len(commands))
+	for index := range commands {
+		commands[index] = exec.Command(
+			cliPath, "install",
+			"--bundle", bundlePath,
+			"--expected-sha256", bundleDigest,
+			"--store", storePath,
+		)
+		commands[index].Stdout = &outputs[index]
+		commands[index].Stderr = &outputs[index]
+		if err := commands[index].Start(); err != nil {
+			t.Fatalf("start concurrent install %d: %v", index+1, err)
+		}
+	}
+	for index, command := range commands {
+		if err := command.Wait(); err != nil {
+			t.Fatalf("concurrent install %d: %v\n%s", index+1, err, &outputs[index])
+		}
+	}
+	installed, err := os.ReadDir(filepath.Join(storePath, "sha256"))
+	if err != nil {
+		t.Fatal("list content-addressed Profile store:", err)
+	}
+	if len(installed) != 1 || installed[0].Name() != bundleDigest {
+		t.Fatalf("concurrent installs published %#v, want only %q", installed, bundleDigest)
+	}
+	staging, err := os.ReadDir(filepath.Join(storePath, ".staging"))
+	if err != nil || len(staging) != 0 {
+		t.Fatalf("concurrent installs left staging entries=%#v err=%v", staging, err)
+	}
+}
+
+func TestProfileBundleInstallRejectsMismatchedSystemCallPolicy(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Fatal("profilebundle_root tests must run as root on a disposable Linux environment")
+	}
+	cliPath := os.Getenv("PROFILE_BUNDLE_CLI")
+	if cliPath == "" {
+		t.Fatal("PROFILE_BUNDLE_CLI must name the prebuilt profile-bundle command")
+	}
+
+	temporaryDirectory := t.TempDir()
+	bundlePath := filepath.Join(temporaryDirectory, "mismatched-policy.bundle")
+	mismatchedPolicy := []byte("{\"schema\":\"system-call-policy/v1\",\"profile\":\"another-profile\",\"target\":{\"os\":\"linux\",\"arch\":\"amd64\"},\"default_action\":{\"action\":\"errno\",\"errno\":1},\"rules\":[]}\n")
+	bundleDigest := writeIndependentBundleFixture(t, bundlePath, validFixtureLock(), mismatchedPolicy)
+	storePath := filepath.Join(temporaryDirectory, "profile-store")
+	if err := os.Mkdir(storePath, 0o755); err != nil {
+		t.Fatal("create Profile store:", err)
+	}
+
+	command := exec.Command(
+		cliPath, "install",
+		"--bundle", bundlePath,
+		"--expected-sha256", bundleDigest,
+		"--store", storePath,
+	)
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("install accepted a System Call Policy for another profile:\n%s", output)
+	}
+	if entries, err := os.ReadDir(filepath.Join(storePath, "sha256")); err != nil || len(entries) != 0 {
+		t.Fatalf("rejected Policy published a Profile: entries=%#v err=%v", entries, err)
+	}
+}
+
+func TestProfileBundleInstallRejectsMismatchedBuildLock(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Fatal("profilebundle_root tests must run as root on a disposable Linux environment")
+	}
+	cliPath := os.Getenv("PROFILE_BUNDLE_CLI")
+	if cliPath == "" {
+		t.Fatal("PROFILE_BUNDLE_CLI must name the prebuilt profile-bundle command")
+	}
+
+	temporaryDirectory := t.TempDir()
+	bundlePath := filepath.Join(temporaryDirectory, "mismatched-lock.bundle")
+	mismatchedLock := bytes.Replace(validFixtureLock(), []byte(`"profile":"python-data-v1"`), []byte(`"profile":"another-profile"`), 1)
+	bundleDigest := writeIndependentBundleFixture(t, bundlePath, mismatchedLock, validFixturePolicy())
+	storePath := filepath.Join(temporaryDirectory, "profile-store")
+	if err := os.Mkdir(storePath, 0o755); err != nil {
+		t.Fatal("create Profile store:", err)
+	}
+
+	command := exec.Command(
+		cliPath, "install",
+		"--bundle", bundlePath,
+		"--expected-sha256", bundleDigest,
+		"--store", storePath,
+	)
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("install accepted a build lock for another profile:\n%s", output)
+	}
+	if entries, err := os.ReadDir(filepath.Join(storePath, "sha256")); err != nil || len(entries) != 0 {
+		t.Fatalf("rejected build lock published a Profile: entries=%#v err=%v", entries, err)
+	}
+}
+
+func TestProfileBundleInstallRejectsAlteredDeclaredComponent(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Fatal("profilebundle_root tests must run as root on a disposable Linux environment")
+	}
+	cliPath := os.Getenv("PROFILE_BUNDLE_CLI")
+	if cliPath == "" {
+		t.Fatal("PROFILE_BUNDLE_CLI must name the prebuilt profile-bundle command")
+	}
+
+	temporaryDirectory := t.TempDir()
+	bundlePath := filepath.Join(temporaryDirectory, "altered-component.bundle")
+	writeIndependentBundleFixture(t, bundlePath, validFixtureLock(), validFixturePolicy())
+	bundleDigest := rewriteIndependentBundleFixture(t, bundlePath, func(entries []independentOuterEntry) []independentOuterEntry {
+		for index := range entries {
+			if entries[index].name == "sandbox-init" {
+				entries[index].contents = []byte("abd")
+				return entries
+			}
+		}
+		t.Fatal("independent fixture has no Sandbox Init to alter")
+		return nil
+	})
+	storePath := filepath.Join(temporaryDirectory, "profile-store")
+	if err := os.Mkdir(storePath, 0o755); err != nil {
+		t.Fatal("create Profile store:", err)
+	}
+
+	command := exec.Command(
+		cliPath, "install",
+		"--bundle", bundlePath,
+		"--expected-sha256", bundleDigest,
+		"--store", storePath,
+	)
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("install accepted an altered declared component:\n%s", output)
+	}
+	if entries, err := os.ReadDir(filepath.Join(storePath, "sha256")); err != nil || len(entries) != 0 {
+		t.Fatalf("altered component published a Profile: entries=%#v err=%v", entries, err)
+	}
+}
+
+func TestProfileBundleInstallRejectsMissingDeclaredComponent(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Fatal("profilebundle_root tests must run as root on a disposable Linux environment")
+	}
+	cliPath := os.Getenv("PROFILE_BUNDLE_CLI")
+	if cliPath == "" {
+		t.Fatal("PROFILE_BUNDLE_CLI must name the prebuilt profile-bundle command")
+	}
+
+	temporaryDirectory := t.TempDir()
+	bundlePath := filepath.Join(temporaryDirectory, "missing-component.bundle")
+	writeIndependentBundleFixture(t, bundlePath, validFixtureLock(), validFixturePolicy())
+	bundleDigest := rewriteIndependentBundleFixture(t, bundlePath, func(entries []independentOuterEntry) []independentOuterEntry {
+		for index := range entries {
+			if entries[index].name == "sandbox-init" {
+				return append(entries[:index], entries[index+1:]...)
+			}
+		}
+		t.Fatal("independent fixture has no Sandbox Init to remove")
+		return nil
+	})
+	storePath := filepath.Join(temporaryDirectory, "profile-store")
+	if err := os.Mkdir(storePath, 0o755); err != nil {
+		t.Fatal("create Profile store:", err)
+	}
+
+	command := exec.Command(
+		cliPath, "install",
+		"--bundle", bundlePath,
+		"--expected-sha256", bundleDigest,
+		"--store", storePath,
+	)
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("install accepted a Bundle missing a declared component:\n%s", output)
+	}
+	if entries, err := os.ReadDir(filepath.Join(storePath, "sha256")); err != nil || len(entries) != 0 {
+		t.Fatalf("missing component published a Profile: entries=%#v err=%v", entries, err)
+	}
+}
+
+func TestProfileBundleInstallRejectsUnlistedComponent(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Fatal("profilebundle_root tests must run as root on a disposable Linux environment")
+	}
+	cliPath := os.Getenv("PROFILE_BUNDLE_CLI")
+	if cliPath == "" {
+		t.Fatal("PROFILE_BUNDLE_CLI must name the prebuilt profile-bundle command")
+	}
+
+	temporaryDirectory := t.TempDir()
+	bundlePath := filepath.Join(temporaryDirectory, "unlisted-component.bundle")
+	writeIndependentBundleFixture(t, bundlePath, validFixtureLock(), validFixturePolicy())
+	bundleDigest := rewriteIndependentBundleFixture(t, bundlePath, func(entries []independentOuterEntry) []independentOuterEntry {
+		return append(entries, independentOuterEntry{name: "unexpected-component", mode: 0o444, contents: []byte("unexpected")})
+	})
+	storePath := filepath.Join(temporaryDirectory, "profile-store")
+	if err := os.Mkdir(storePath, 0o755); err != nil {
+		t.Fatal("create Profile store:", err)
+	}
+
+	command := exec.Command(
+		cliPath, "install",
+		"--bundle", bundlePath,
+		"--expected-sha256", bundleDigest,
+		"--store", storePath,
+	)
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("install accepted an unlisted component:\n%s", output)
+	}
+	if entries, err := os.ReadDir(filepath.Join(storePath, "sha256")); err != nil || len(entries) != 0 {
+		t.Fatalf("unlisted component published a Profile: entries=%#v err=%v", entries, err)
+	}
+}
+
+func TestProfileBundleInstallRejectsUnexpectedBundleDigest(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Fatal("profilebundle_root tests must run as root on a disposable Linux environment")
+	}
+	cliPath := os.Getenv("PROFILE_BUNDLE_CLI")
+	if cliPath == "" {
+		t.Fatal("PROFILE_BUNDLE_CLI must name the prebuilt profile-bundle command")
+	}
+
+	temporaryDirectory := t.TempDir()
+	bundlePath := filepath.Join(temporaryDirectory, "unexpected-digest.bundle")
+	writeIndependentBundleFixture(t, bundlePath, validFixtureLock(), validFixturePolicy())
+	storePath := filepath.Join(temporaryDirectory, "profile-store")
+	if err := os.Mkdir(storePath, 0o755); err != nil {
+		t.Fatal("create Profile store:", err)
+	}
+
+	command := exec.Command(
+		cliPath, "install",
+		"--bundle", bundlePath,
+		"--expected-sha256", "0000000000000000000000000000000000000000000000000000000000000000",
+		"--store", storePath,
+	)
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("install accepted an unexpected external Bundle digest:\n%s", output)
+	}
+	for _, directory := range []string{"sha256", ".staging"} {
+		entries, err := os.ReadDir(filepath.Join(storePath, directory))
+		if err != nil || len(entries) != 0 {
+			t.Fatalf("unexpected digest left entries in %s: entries=%#v err=%v", directory, entries, err)
+		}
+	}
+}
+
+func TestProfileBundleInstallDoesNotEscapeProfileStore(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Fatal("profilebundle_root tests must run as root on a disposable Linux environment")
+	}
+	cliPath := os.Getenv("PROFILE_BUNDLE_CLI")
+	if cliPath == "" {
+		t.Fatal("PROFILE_BUNDLE_CLI must name the prebuilt profile-bundle command")
+	}
+
+	temporaryDirectory := t.TempDir()
+	sentinelPath := filepath.Join(temporaryDirectory, "sentinel")
+	if err := os.WriteFile(sentinelPath, []byte("safe"), 0o644); err != nil {
+		t.Fatal("write host sentinel:", err)
+	}
+	maliciousRootFS := writeIndependentRootFSFixture(t, "../../../../sentinel", []byte("tampered"))
+	bundlePath := filepath.Join(temporaryDirectory, "path-escape.bundle")
+	bundleDigest := writeIndependentBundleFixtureWithRootFS(t, bundlePath, validFixtureLock(), validFixturePolicy(), maliciousRootFS)
+	storePath := filepath.Join(temporaryDirectory, "profile-store")
+	if err := os.Mkdir(storePath, 0o755); err != nil {
+		t.Fatal("create Profile store:", err)
+	}
+
+	command := exec.Command(
+		cliPath, "install",
+		"--bundle", bundlePath,
+		"--expected-sha256", bundleDigest,
+		"--store", storePath,
+	)
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("install accepted a root filesystem path escape:\n%s", output)
+	}
+	sentinel, err := os.ReadFile(sentinelPath)
+	if err != nil {
+		t.Fatal("read host sentinel after rejected install:", err)
+	}
+	if string(sentinel) != "safe" {
+		t.Fatalf("root filesystem path escape changed host sentinel to %q", sentinel)
+	}
+	if entries, err := os.ReadDir(filepath.Join(storePath, "sha256")); err != nil || len(entries) != 0 {
+		t.Fatalf("path escape published a Profile: entries=%#v err=%v", entries, err)
+	}
+}
+
+func TestProfileBundleInstallRejectsManifestThatContradictsBuildLock(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Fatal("profilebundle_root tests must run as root on a disposable Linux environment")
+	}
+	cliPath := os.Getenv("PROFILE_BUNDLE_CLI")
+	if cliPath == "" {
+		t.Fatal("PROFILE_BUNDLE_CLI must name the prebuilt profile-bundle command")
+	}
+
+	temporaryDirectory := t.TempDir()
+	bundlePath := filepath.Join(temporaryDirectory, "contradictory-manifest.bundle")
+	writeIndependentBundleFixture(t, bundlePath, validFixtureLock(), validFixturePolicy())
+	bundleDigest := rewriteIndependentBundleFixture(t, bundlePath, func(entries []independentOuterEntry) []independentOuterEntry {
+		for index := range entries {
+			if entries[index].name == "manifest.json" {
+				entries[index].contents = bytes.Replace(
+					entries[index].contents,
+					[]byte(`"entrypoint":"/opt/python/bin/python3"`),
+					[]byte(`"entrypoint":"/opt/python/bin/python9"`),
+					1,
+				)
+				return entries
+			}
+		}
+		t.Fatal("independent fixture has no manifest to contradict")
+		return nil
+	})
+	storePath := filepath.Join(temporaryDirectory, "profile-store")
+	if err := os.Mkdir(storePath, 0o755); err != nil {
+		t.Fatal("create Profile store:", err)
+	}
+
+	command := exec.Command(
+		cliPath, "install",
+		"--bundle", bundlePath,
+		"--expected-sha256", bundleDigest,
+		"--store", storePath,
+	)
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("install accepted a manifest that contradicts its build lock:\n%s", output)
+	}
+	if entries, err := os.ReadDir(filepath.Join(storePath, "sha256")); err != nil || len(entries) != 0 {
+		t.Fatalf("contradictory manifest published a Profile: entries=%#v err=%v", entries, err)
+	}
+}
+
+func TestProfileBundleInstallRejectsEscapingRootFilesystemSymlink(t *testing.T) {
+	rootfs := writeIndependentRootFSEntry(t, &tar.Header{
+		Name:     "opt/python/bin/python3",
+		Linkname: "../../../../sentinel",
+		Mode:     0o555,
+		Uid:      0,
+		Gid:      0,
+		ModTime:  time.Unix(0, 0).UTC(),
+		Typeflag: tar.TypeSymlink,
+		Format:   tar.FormatPAX,
+	}, nil)
+	assertRootFSRejectedWithoutPublish(t, rootfs)
+}
+
+func TestProfileBundleInstallRejectsRootFilesystemHardLink(t *testing.T) {
+	rootfs := writeIndependentRootFSEntry(t, &tar.Header{
+		Name:     "opt/python/bin/python3",
+		Linkname: "opt/python/bin/other",
+		Mode:     0o555,
+		Uid:      0,
+		Gid:      0,
+		ModTime:  time.Unix(0, 0).UTC(),
+		Typeflag: tar.TypeLink,
+		Format:   tar.FormatPAX,
+	}, nil)
+	assertRootFSRejectedWithoutPublish(t, rootfs)
+}
+
+func TestProfileBundleInstallRejectsRootFilesystemDevice(t *testing.T) {
+	rootfs := writeIndependentRootFSEntry(t, &tar.Header{
+		Name:     "dev/host-device",
+		Mode:     0o444,
+		Uid:      0,
+		Gid:      0,
+		Devmajor: 1,
+		Devminor: 3,
+		ModTime:  time.Unix(0, 0).UTC(),
+		Typeflag: tar.TypeChar,
+		Format:   tar.FormatPAX,
+	}, nil)
+	assertRootFSRejectedWithoutPublish(t, rootfs)
+}
+
+func TestProfileBundleInstallRejectsMissingPythonEntrypoint(t *testing.T) {
+	rootfs := writeIndependentRootFSFixture(t, "opt/python/bin/not-python", []byte("fixture"))
+	assertRootFSRejectedWithoutPublish(t, rootfs)
+}
+
+func assertRootFSRejectedWithoutPublish(t *testing.T, rootfs []byte) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Fatal("profilebundle_root tests must run as root on a disposable Linux environment")
+	}
+	cliPath := os.Getenv("PROFILE_BUNDLE_CLI")
+	if cliPath == "" {
+		t.Fatal("PROFILE_BUNDLE_CLI must name the prebuilt profile-bundle command")
+	}
+	temporaryDirectory := t.TempDir()
+	bundlePath := filepath.Join(temporaryDirectory, "unsafe-rootfs.bundle")
+	bundleDigest := writeIndependentBundleFixtureWithRootFS(t, bundlePath, validFixtureLock(), validFixturePolicy(), rootfs)
+	storePath := filepath.Join(temporaryDirectory, "profile-store")
+	if err := os.Mkdir(storePath, 0o755); err != nil {
+		t.Fatal("create Profile store:", err)
+	}
+	command := exec.Command(
+		cliPath, "install",
+		"--bundle", bundlePath,
+		"--expected-sha256", bundleDigest,
+		"--store", storePath,
+	)
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("install accepted an unsafe root filesystem entry:\n%s", output)
+	}
+	if entries, err := os.ReadDir(filepath.Join(storePath, "sha256")); err != nil || len(entries) != 0 {
+		t.Fatalf("unsafe root filesystem published a Profile: entries=%#v err=%v", entries, err)
+	}
+}
+
+func validFixtureLock() []byte {
+	return []byte("{\"schema\":\"profile-build-lock/v1\",\"profile\":\"python-data-v1\",\"target\":{\"os\":\"linux\",\"arch\":\"amd64\"},\"python\":{\"version\":\"3.14.7\",\"entrypoint\":\"/opt/python/bin/python3\",\"packages\":[]},\"inputs\":[{\"id\":\"fixture\",\"kind\":\"python-install-only\",\"version\":\"3.14.7+fixture\",\"source\":\"https://example.invalid/python.tar.gz\",\"filename\":\"python.tar.gz\",\"size\":1,\"digest\":\"sha256:0000000000000000000000000000000000000000000000000000000000000000\",\"archive_prefix\":\"python/\",\"destination\":\"opt/python/\",\"include\":[],\"exclude\":[]}]}\n")
+}
+
+func validFixturePolicy() []byte {
+	return []byte("{\"schema\":\"system-call-policy/v1\",\"profile\":\"python-data-v1\",\"target\":{\"os\":\"linux\",\"arch\":\"amd64\"},\"default_action\":{\"action\":\"errno\",\"errno\":1},\"rules\":[]}\n")
+}
+
+func writeIndependentBundleFixture(t *testing.T, bundlePath string, lock, policy []byte) string {
+	t.Helper()
+	rootfs := writeIndependentRootFSFixture(t, "opt/python/bin/python3", []byte("fixture-python"))
+	return writeIndependentBundleFixtureWithRootFS(t, bundlePath, lock, policy, rootfs)
+}
+
+func writeIndependentRootFSFixture(t *testing.T, name string, contents []byte) []byte {
+	t.Helper()
+	return writeIndependentRootFSEntry(t, &tar.Header{
+		Name:     name,
+		Mode:     0o555,
+		Size:     int64(len(contents)),
+		Uid:      0,
+		Gid:      0,
+		ModTime:  time.Unix(0, 0).UTC(),
+		Typeflag: tar.TypeReg,
+		Format:   tar.FormatPAX,
+	}, contents)
+}
+
+func writeIndependentRootFSEntry(t *testing.T, header *tar.Header, contents []byte) []byte {
+	t.Helper()
+	var rootfs bytes.Buffer
+	rootfsWriter := tar.NewWriter(&rootfs)
+	if err := rootfsWriter.WriteHeader(header); err != nil {
+		t.Fatal("write fixture root filesystem header:", err)
+	}
+	if _, err := rootfsWriter.Write(contents); err != nil {
+		t.Fatal("write fixture root filesystem contents:", err)
+	}
+	if err := rootfsWriter.Close(); err != nil {
+		t.Fatal("close fixture root filesystem:", err)
+	}
+	return rootfs.Bytes()
+}
+
+func writeIndependentBundleFixtureWithRootFS(t *testing.T, bundlePath string, lock, policy, rootfs []byte) string {
+	t.Helper()
+	init := []byte("abc")
+
+	type fixtureComponent struct {
+		role       string
+		path       string
+		format     string
+		mode       string
+		contents   []byte
+		sha256Text string
+	}
+	components := []fixtureComponent{
+		{role: "build-lock", path: "profile.lock.json", format: "profile-build-lock/v1", mode: "0444", contents: lock},
+		{role: "system-call-policy", path: "system-call-policy.json", format: "system-call-policy/v1", mode: "0444", contents: policy},
+		{role: "sandbox-init", path: "sandbox-init", format: "opaque/v1", mode: "0555", contents: init},
+		{role: "rootfs", path: "rootfs.tar", format: "rootfs-pax-tar/v1", mode: "0444", contents: rootfs},
+	}
+	for index := range components {
+		components[index].sha256Text = independentSHA256(components[index].contents)
+	}
+
+	manifest := fmt.Sprintf(
+		"{\"schema\":\"profile-bundle-manifest/v1\",\"profile\":\"python-data-v1\",\"target\":{\"os\":\"linux\",\"arch\":\"amd64\"},\"python\":{\"version\":\"3.14.7\",\"entrypoint\":\"/opt/python/bin/python3\",\"packages\":[]},\"components\":["+
+			"{\"role\":\"build-lock\",\"path\":\"profile.lock.json\",\"format\":\"profile-build-lock/v1\",\"mode\":\"0444\",\"size\":%d,\"digest\":\"sha256:%s\"},"+
+			"{\"role\":\"system-call-policy\",\"path\":\"system-call-policy.json\",\"format\":\"system-call-policy/v1\",\"mode\":\"0444\",\"size\":%d,\"digest\":\"sha256:%s\"},"+
+			"{\"role\":\"sandbox-init\",\"path\":\"sandbox-init\",\"format\":\"opaque/v1\",\"mode\":\"0555\",\"size\":%d,\"digest\":\"sha256:%s\"},"+
+			"{\"role\":\"rootfs\",\"path\":\"rootfs.tar\",\"format\":\"rootfs-pax-tar/v1\",\"mode\":\"0444\",\"size\":%d,\"digest\":\"sha256:%s\"}]}\n",
+		len(lock), components[0].sha256Text,
+		len(policy), components[1].sha256Text,
+		len(init), components[2].sha256Text,
+		len(rootfs), components[3].sha256Text,
+	)
+
+	file, err := os.Create(bundlePath)
+	if err != nil {
+		t.Fatal("create independent Profile Bundle fixture:", err)
+	}
+	bundleWriter := tar.NewWriter(file)
+	writeIndependentOuterEntry(t, bundleWriter, "manifest.json", 0o444, []byte(manifest))
+	for _, component := range components {
+		mode := int64(0o444)
+		if component.mode == "0555" {
+			mode = 0o555
+		}
+		writeIndependentOuterEntry(t, bundleWriter, component.path, mode, component.contents)
+	}
+	if err := bundleWriter.Close(); err != nil {
+		t.Fatal("close independent Profile Bundle fixture tar:", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal("close independent Profile Bundle fixture:", err)
+	}
+
+	bundleBytes, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatal("read independent Profile Bundle fixture:", err)
+	}
+	return independentSHA256(bundleBytes)
+}
+
+func writeIndependentOuterEntry(t *testing.T, writer *tar.Writer, name string, mode int64, contents []byte) {
+	t.Helper()
+	header := &tar.Header{
+		Name:     name,
+		Mode:     mode,
+		Size:     int64(len(contents)),
+		Uid:      0,
+		Gid:      0,
+		ModTime:  time.Unix(0, 0).UTC(),
+		Typeflag: tar.TypeReg,
+		Format:   tar.FormatUSTAR,
+	}
+	if err := writer.WriteHeader(header); err != nil {
+		t.Fatalf("write independent fixture entry %q header: %v", name, err)
+	}
+	if _, err := writer.Write(contents); err != nil {
+		t.Fatalf("write independent fixture entry %q: %v", name, err)
+	}
+}
+
+func independentSHA256(contents []byte) string {
+	digest := sha256.Sum256(contents)
+	return hex.EncodeToString(digest[:])
+}
+
+type independentOuterEntry struct {
+	name     string
+	mode     int64
+	contents []byte
+}
+
+func rewriteIndependentBundleFixture(t *testing.T, bundlePath string, mutate func([]independentOuterEntry) []independentOuterEntry) string {
+	t.Helper()
+
+	file, err := os.Open(bundlePath)
+	if err != nil {
+		t.Fatal("open independent Profile Bundle fixture for rewrite:", err)
+	}
+	reader := tar.NewReader(file)
+	var entries []independentOuterEntry
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			file.Close()
+			t.Fatal("read independent Profile Bundle fixture for rewrite:", err)
+		}
+		contents, err := io.ReadAll(reader)
+		if err != nil {
+			file.Close()
+			t.Fatalf("read independent entry %q for rewrite: %v", header.Name, err)
+		}
+		entries = append(entries, independentOuterEntry{name: header.Name, mode: header.Mode, contents: contents})
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal("close independent Profile Bundle fixture before rewrite:", err)
+	}
+	entries = mutate(entries)
+
+	file, err = os.Create(bundlePath)
+	if err != nil {
+		t.Fatal("recreate independent Profile Bundle fixture:", err)
+	}
+	writer := tar.NewWriter(file)
+	for _, entry := range entries {
+		writeIndependentOuterEntry(t, writer, entry.name, entry.mode, entry.contents)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal("close rewritten independent Profile Bundle fixture tar:", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal("close rewritten independent Profile Bundle fixture:", err)
+	}
+	bundleBytes, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatal("read rewritten independent Profile Bundle fixture:", err)
+	}
+	return independentSHA256(bundleBytes)
+}

--- a/tests/profile_bundle_production_linux_test.go
+++ b/tests/profile_bundle_production_linux_test.go
@@ -1,0 +1,165 @@
+//go:build linux && profilebundle_production
+
+package workspace_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPythonDataV1ProductionBuildIsByteReproducible(t *testing.T) {
+	cliPath := requiredEnvironment(t, "PROFILE_BUNDLE_CLI")
+	repositoryRoot := requiredEnvironment(t, "PROFILE_BUNDLE_REPOSITORY_ROOT")
+	sourceCache := requiredEnvironment(t, "PROFILE_BUNDLE_SOURCE_CACHE")
+
+	temporaryDirectory := t.TempDir()
+	initPath := filepath.Join(temporaryDirectory, "sandbox-init.fixture")
+	if err := os.WriteFile(initPath, []byte("abc"), 0o755); err != nil {
+		t.Fatal("write opaque Sandbox Init fixture:", err)
+	}
+	bundlePaths := []string{
+		filepath.Join(temporaryDirectory, "first.bundle"),
+		filepath.Join(temporaryDirectory, "second.bundle"),
+	}
+	reportedDigests := make([]string, len(bundlePaths))
+	for index, bundlePath := range bundlePaths {
+		command := exec.Command(
+			cliPath, "build",
+			"--lock", filepath.Join(repositoryRoot, "profiles", "python-data-v1", "profile.lock.json"),
+			"--source-cache", sourceCache,
+			"--system-call-policy", filepath.Join(repositoryRoot, "profiles", "python-data-v1", "system-call-policy.json"),
+			"--sandbox-init", initPath,
+			"--output", bundlePath,
+		)
+		if index == 0 {
+			command.Env = append(os.Environ(), "TZ=UTC")
+		} else {
+			command.Env = append(os.Environ(), "TZ=Asia/Shanghai")
+		}
+		output, err := command.CombinedOutput()
+		if err != nil {
+			t.Fatalf("build production python-data-v1 Profile Bundle %d: %v\n%s", index+1, err, output)
+		}
+		reportedDigests[index] = strings.TrimSpace(string(output))
+	}
+
+	first, err := os.ReadFile(bundlePaths[0])
+	if err != nil {
+		t.Fatal("read first production Profile Bundle:", err)
+	}
+	second, err := os.ReadFile(bundlePaths[1])
+	if err != nil {
+		t.Fatal("read second production Profile Bundle:", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("identical locked inputs produced different Profile Bundle bytes")
+	}
+	digest := sha256.Sum256(first)
+	wantDigest := hex.EncodeToString(digest[:])
+	if reportedDigests[0] != wantDigest || reportedDigests[1] != wantDigest {
+		t.Fatalf("reported production Bundle digests = %#v, want %q", reportedDigests, wantDigest)
+	}
+	var manifest struct {
+		Components []struct {
+			Role   string `json:"role"`
+			Digest string `json:"digest"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal(readOuterBundle(t, bundlePaths[0])["manifest.json"], &manifest); err != nil {
+		t.Fatal("decode production Profile Bundle manifest:", err)
+	}
+	wantComponentDigests := map[string]string{
+		"rootfs":             "sha256:cdfacca4d70a2045c924b491e9d7516fbf3c67dbce950b70f1207c204d3a46aa",
+		"system-call-policy": "sha256:6003c746e5e4156c755f1f365ad0f605420c5236231125e97738ee6af54afdc3",
+	}
+	for _, component := range manifest.Components {
+		if want, ok := wantComponentDigests[component.Role]; ok {
+			if component.Digest != want {
+				t.Fatalf("production %s digest = %q, want reviewed %q", component.Role, component.Digest, want)
+			}
+			delete(wantComponentDigests, component.Role)
+		}
+	}
+	if len(wantComponentDigests) != 0 {
+		t.Fatalf("production manifest omitted reviewed component digests: %#v", wantComponentDigests)
+	}
+}
+
+func TestPythonDataV1ProductionRuntimeProvidesLockedStandardLibrary(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Fatal("profilebundle_production tests must run as root on a disposable Linux environment")
+	}
+	cliPath := requiredEnvironment(t, "PROFILE_BUNDLE_CLI")
+	repositoryRoot := requiredEnvironment(t, "PROFILE_BUNDLE_REPOSITORY_ROOT")
+	sourceCache := requiredEnvironment(t, "PROFILE_BUNDLE_SOURCE_CACHE")
+
+	temporaryDirectory := t.TempDir()
+	initPath := filepath.Join(temporaryDirectory, "sandbox-init.fixture")
+	if err := os.WriteFile(initPath, []byte("abc"), 0o755); err != nil {
+		t.Fatal("write opaque Sandbox Init fixture:", err)
+	}
+	bundlePath := filepath.Join(temporaryDirectory, "python-data-v1.bundle")
+	build := exec.Command(
+		cliPath, "build",
+		"--lock", filepath.Join(repositoryRoot, "profiles", "python-data-v1", "profile.lock.json"),
+		"--source-cache", sourceCache,
+		"--system-call-policy", filepath.Join(repositoryRoot, "profiles", "python-data-v1", "system-call-policy.json"),
+		"--sandbox-init", initPath,
+		"--output", bundlePath,
+	)
+	buildOutput, err := build.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build production python-data-v1 Profile Bundle: %v\n%s", err, buildOutput)
+	}
+	bundleDigest := strings.TrimSpace(string(buildOutput))
+
+	storePath := filepath.Join(temporaryDirectory, "profile-store")
+	if err := os.Mkdir(storePath, 0o755); err != nil {
+		t.Fatal("create production Profile store:", err)
+	}
+	install := exec.Command(
+		cliPath, "install",
+		"--bundle", bundlePath,
+		"--expected-sha256", bundleDigest,
+		"--store", storePath,
+	)
+	if output, err := install.CombinedOutput(); err != nil {
+		t.Fatalf("install production python-data-v1 Profile Bundle: %v\n%s", err, output)
+	}
+
+	rootfsPath := filepath.Join(storePath, "sha256", bundleDigest, "rootfs")
+	smoke := strings.Join([]string{
+		"import csv, importlib.util, json, platform, sqlite3",
+		"assert platform.python_version() == '3.14.7'",
+		"assert importlib.util.find_spec('pip') is None",
+		"assert importlib.util.find_spec('ensurepip') is None",
+		"assert json.loads('{\"answer\": 42}')['answer'] == 42",
+		"assert next(csv.reader(['a,b'])) == ['a', 'b']",
+		"assert sqlite3.connect(':memory:').execute('select 42').fetchone()[0] == 42",
+		"print('profile-smoke-ok')",
+	}, "; ")
+	python := exec.Command("chroot", rootfsPath, "/opt/python/bin/python3", "-I", "-c", smoke)
+	output, err := python.CombinedOutput()
+	if err != nil {
+		t.Fatalf("run production python-data-v1 content smoke: %v\n%s", err, output)
+	}
+	if string(output) != "profile-smoke-ok\n" {
+		t.Fatalf("production python-data-v1 smoke output = %q, want %q", output, "profile-smoke-ok\n")
+	}
+}
+
+func requiredEnvironment(t *testing.T, name string) string {
+	t.Helper()
+	value := os.Getenv(name)
+	if value == "" {
+		t.Fatalf("%s must be set", name)
+	}
+	return value
+}


### PR DESCRIPTION
## Summary

- define the deterministic Profile Bundle v1 format and the profile-bundle build/install CLI
- lock python-data-v1 to reviewed linux/amd64 CPython and musl inputs with SHA-256 identities
- add root-owned, content-addressed, atomic Linux installation with strict schema, component, path, topology, and resource validation
- add fast public-boundary tests plus real Linux root installation, reproducibility, and CPython content coverage
- document the format, trust boundary, and the T08 release gate for the default-deny candidate System Call Policy

## Local validation

- go test ./...
- go vet ./... and go build ./... on Windows and linux/amd64
- 15 Linux root installer and adversarial tests
- two byte-identical production builds with reviewed component digests
- root installation followed by CPython 3.14.7 chroot smoke
- final Standards, Spec, and adversarial reviews: no unresolved P1/P2 findings

## Scope boundary

This change records an externally supplied Sandbox Init but does not implement its PID 1 behavior. User Namespaces, pivot_root, read-only mounting, and System Call Policy enforcement remain in their downstream tickets. The current Policy is a digest-bound default-deny candidate and is not promoted for Workload execution before T08.

Closes #8