### PR TITLE
docs: credit project contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,4 @@
+# Contributors / 贡献者
+
+- [TH1NKING](https://github.com/TH1NKING) — 项目创建者与维护者。
+- [OpenAI Codex](https://openai.com/codex/) — AI 工程协作者，参与架构分析、测试驱动实现、安全审查、文档与验证。所有仓库变更仍由人类维护者发起、审阅并接受。

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@
 - `cmd/profile-bundle`：构建和 root-owned 安装 `python-data-v1` Profile Bundle 的公开工具。
 - `profiles/python-data-v1`：锁定的 Runtime Profile 输入与候选 System Call Policy。
 - `docs/adr` 与 `CONTEXT.md`：目标系统的架构决策和上下文文档。
+- [`CONTRIBUTORS.md`](CONTRIBUTORS.md)：项目贡献者与协作者署名。
+
+## 贡献者与协作者
+
+感谢所有帮助这个项目成长的人与协作工具；完整署名见 [`CONTRIBUTORS.md`](CONTRIBUTORS.md)。
 
 ## Linux 前置条件
 


### PR DESCRIPTION
## Summary

- add a CONTRIBUTORS.md file for transparent contributor and collaborator credit
- credit TH1NKING as project creator and maintainer
- credit OpenAI Codex as an AI engineering collaborator while preserving human direction, review, and accountability
- link the contributor record from README