### PR TITLE
feat: establish sandbox supervisor protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - `with_shell`：Shell 版对照实验；仅用于教学和行为比较。
 - `tests`：面向公开命令入口的 Linux 验收测试。
 - `cmd/profile-bundle`：构建和 root-owned 安装 `python-data-v1` Profile Bundle 的公开工具。
+- `cmd/sandboxd`：Linux 上的特权 Sandbox Supervisor 入口；仅开放受限本地协议，不接受通用宿主机命令或路径。
 - `profiles/python-data-v1`：锁定的 Runtime Profile 输入与候选 System Call Policy。
 - `docs/adr` 与 `CONTEXT.md`：目标系统的架构决策和上下文文档。
 - [`CONTRIBUTORS.md`](CONTRIBUTORS.md)：项目贡献者与协作者署名。
@@ -48,6 +49,8 @@ bash -n with_shell/*.sh
 GitHub Actions 会在 Ubuntu 上对 push 和 pull request 执行同一个 `make check`，因此本地与 CI 使用相同的验收入口。
 
 Profile Bundle 另有一个 Linux root 验收 job：它校验锁定下载、两次可复现构建、root-owned 原子安装、恶意 Bundle 拒绝以及真实 CPython 内容 smoke。格式和命令合同见 [`docs/profile-bundle-v1.md`](docs/profile-bundle-v1.md)。
+
+Sandbox Supervisor 协议测试必须以普通 Linux 用户运行，通过真实 Unix socket 验证版本、封闭 operation 集合、严格消息解析、受信路径和权限边界；协议与 `sandboxd` 启动合同见 [`docs/sandbox-supervisor-protocol-v1.md`](docs/sandbox-supervisor-protocol-v1.md)。真实 User Namespace、`pivot_root` 和 Sandbox 创建属于后续实现，T03 不会返回虚假的创建成功。
 
 ## 使用 Go Runtime Lab
 

--- a/cmd/sandboxd/main_linux.go
+++ b/cmd/sandboxd/main_linux.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/TH1NKING/Build-your-own-Docker-with-Go/internal/sandboxsupervisor"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "sandboxd:", err)
+		os.Exit(1)
+	}
+}
+
+func run(arguments []string) error {
+	flags := flag.NewFlagSet("sandboxd", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+
+	var config sandboxsupervisor.ServerConfig
+	flags.StringVar(&config.SocketPath, "socket", "", "absolute path for the restricted Worker socket")
+	flags.StringVar(&config.ProfileStore, "profile-store", "", "absolute path to the root-owned Profile store")
+	flags.StringVar(&config.SandboxRoot, "sandbox-root", "", "absolute path to the runtime-owned Sandbox root")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("unexpected positional arguments: %v", flags.Args())
+	}
+	if config.SocketPath == "" || config.ProfileStore == "" || config.SandboxRoot == "" {
+		return errors.New("--socket, --profile-store, and --sandbox-root are required")
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return sandboxsupervisor.Serve(ctx, config)
+}

--- a/docs/sandbox-supervisor-protocol-v1.md
+++ b/docs/sandbox-supervisor-protocol-v1.md
@@ -1,0 +1,117 @@
+# Sandbox Supervisor protocol v1
+
+The Sandbox Supervisor protocol is the closed local boundary between an
+unprivileged Worker Node and the privileged `sandboxd` process. It is available
+only on Linux and does not expose shell commands, arbitrary host paths, mount
+operations, process identifiers, or caller-selected isolation settings.
+
+This version establishes the transport and validation boundary required by
+T03. T04 implements actual Sandbox creation. Until then, a valid
+`create_sandbox` request whose Profile exists returns `operation_unavailable`
+instead of claiming that an isolated Sandbox was created.
+
+## Trusted startup configuration
+
+`sandboxd` requires three absolute paths:
+
+```text
+--socket <socket-path>
+--profile-store <profile-store-root>
+--sandbox-root <sandbox-runtime-root>
+```
+
+The socket parent, Profile store, and Sandbox root must be real directories
+owned by the `sandboxd` effective UID and must not permit group or other writes.
+The socket parent has the stricter mode and group contract `0750
+<sandboxd-uid>:<sandboxd-effective-gid>`. In production, run `sandboxd` as
+`root:<worker-group>` and provision that directory as `0750
+root:<worker-group>` before startup. The published socket is `0660` and inherits
+that process group, allowing only root and the dedicated Worker group to open
+it.
+
+`sandboxd` refuses to overwrite a pre-existing file, directory, symlink, or
+active socket at the configured socket path.
+
+## Framing
+
+Each connection carries exactly one request and one response, then closes.
+Each message consists of:
+
+1. A four-byte unsigned big-endian payload length.
+2. One UTF-8 JSON payload of that exact length.
+
+Control messages are limited to 65,536 bytes. A declared larger request is
+rejected before its payload is read or allocated. Connections have a bounded
+deadline, and the Supervisor serves up to 16 control connections concurrently
+so an incomplete client cannot block unrelated requests. Bulk Workload input,
+output, or file contents do not belong in this protocol.
+
+JSON decoding is strict. Unknown fields, duplicate fields, trailing values,
+invalid UTF-8, missing required fields, and malformed JSON are rejected.
+
+## Request
+
+The only operation recognized by this protocol version is `create_sandbox`:
+
+```json
+{
+  "schema": "sandbox-supervisor-request/v1",
+  "request_id": "req-001",
+  "operation": "create_sandbox",
+  "parameters": {
+    "sandbox_id": "run-001",
+    "profile_identity": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+  }
+}
+```
+
+`request_id` and `sandbox_id` are opaque identifiers of one to 64 ASCII
+characters. They begin with a lowercase letter or digit; later characters may
+also contain `-` or `_`. `profile_identity` is exactly `sha256:` followed by 64
+lowercase hexadecimal characters.
+
+The client never supplies a Profile path, Sandbox path, Workspace path, host
+PID, UID, GID, command, environment, mount, Network Policy, or Resource Budget.
+`sandboxd` derives filesystem locations beneath its already-open configured
+roots. Profile symlinks and references that cannot be resolved beneath the
+Profile store are rejected.
+
+## Response
+
+Every decodable request receives a v1 response envelope containing exactly one
+of `result` or `error`:
+
+```json
+{
+  "schema": "sandbox-supervisor-response/v1",
+  "request_id": "req-001",
+  "error": {
+    "code": "profile_not_found"
+  }
+}
+```
+
+Stable v1 error codes are:
+
+- `unsupported_version`
+- `unknown_operation`
+- `malformed_request`
+- `invalid_reference`
+- `request_too_large`
+- `profile_not_found`
+- `operation_unavailable`
+
+Errors do not echo raw malformed input or configured host paths.
+
+## Verification
+
+Run the protocol acceptance suite as an ordinary Linux user, not through
+`sudo`:
+
+```sh
+go test ./tests -run '^TestSandboxSupervisor' -count=1
+```
+
+The suite launches the real `sandboxd` command and communicates over a real
+Unix socket. It fails if the client process is root and does not grant the
+client mount, namespace, or cgroup privileges.

--- a/internal/sandboxsupervisor/client_linux.go
+++ b/internal/sandboxsupervisor/client_linux.go
@@ -1,0 +1,66 @@
+//go:build linux
+
+package sandboxsupervisor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+)
+
+type Client struct {
+	socketPath string
+}
+
+func NewClient(socketPath string) *Client {
+	return &Client{socketPath: socketPath}
+}
+
+func (client *Client) CreateSandbox(ctx context.Context, request CreateSandboxRequest) (CreateSandboxResponse, error) {
+	parameters, err := json.Marshal(createSandboxParameters{
+		SandboxID:       request.SandboxID,
+		ProfileIdentity: request.ProfileIdentity,
+	})
+	if err != nil {
+		return CreateSandboxResponse{}, fmt.Errorf("encode Sandbox creation parameters: %w", err)
+	}
+	wireRequest := requestEnvelope{
+		Schema:     RequestSchemaV1,
+		RequestID:  request.RequestID,
+		Operation:  OperationCreateSandbox,
+		Parameters: parameters,
+	}
+	payload, err := json.Marshal(wireRequest)
+	if err != nil {
+		return CreateSandboxResponse{}, fmt.Errorf("encode Sandbox Supervisor request: %w", err)
+	}
+
+	connection, err := (&net.Dialer{}).DialContext(ctx, "unix", client.socketPath)
+	if err != nil {
+		return CreateSandboxResponse{}, fmt.Errorf("connect to Sandbox Supervisor: %w", err)
+	}
+	defer connection.Close()
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := connection.SetDeadline(deadline); err != nil {
+			return CreateSandboxResponse{}, fmt.Errorf("set Sandbox Supervisor request deadline: %w", err)
+		}
+	}
+	if err := writeFrame(connection, payload); err != nil {
+		return CreateSandboxResponse{}, fmt.Errorf("send Sandbox Supervisor request: %w", err)
+	}
+	responsePayload, err := readFrame(connection)
+	if err != nil {
+		return CreateSandboxResponse{}, fmt.Errorf("receive Sandbox Supervisor response: %w", err)
+	}
+	var response responseEnvelope
+	if err := json.Unmarshal(responsePayload, &response); err != nil {
+		return CreateSandboxResponse{}, fmt.Errorf("decode Sandbox Supervisor response: %w", err)
+	}
+	return CreateSandboxResponse{
+		Schema:    response.Schema,
+		RequestID: response.RequestID,
+		Result:    response.Result,
+		Error:     response.Error,
+	}, nil
+}

--- a/internal/sandboxsupervisor/codec_linux.go
+++ b/internal/sandboxsupervisor/codec_linux.go
@@ -1,0 +1,117 @@
+//go:build linux
+
+package sandboxsupervisor
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"unicode/utf8"
+)
+
+func decodeStrictJSON(payload []byte, target any, allowedFields ...string) error {
+	if !utf8.Valid(payload) {
+		return errors.New("JSON is not valid UTF-8")
+	}
+	if err := rejectDuplicateJSONFields(payload); err != nil {
+		return err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		return err
+	}
+	allowed := make(map[string]struct{}, len(allowedFields))
+	for _, field := range allowedFields {
+		allowed[field] = struct{}{}
+	}
+	for field := range fields {
+		if _, ok := allowed[field]; !ok {
+			return fmt.Errorf("JSON object contains unknown field %q", field)
+		}
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return errors.New("JSON contains a trailing value")
+		}
+		return fmt.Errorf("decode trailing JSON value: %w", err)
+	}
+	return nil
+}
+
+func rejectDuplicateJSONFields(payload []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	if err := consumeJSONValue(decoder); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		if err == nil {
+			return errors.New("JSON contains a trailing value")
+		}
+		return fmt.Errorf("decode trailing JSON token: %w", err)
+	}
+	return nil
+}
+
+func consumeJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+
+	switch delimiter {
+	case '{':
+		fields := make(map[string]struct{})
+		for decoder.More() {
+			nameToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			name, ok := nameToken.(string)
+			if !ok {
+				return errors.New("JSON object field name is not a string")
+			}
+			if _, duplicate := fields[name]; duplicate {
+				return fmt.Errorf("JSON object contains duplicate field %q", name)
+			}
+			fields[name] = struct{}{}
+			if err := consumeJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim('}') {
+			return errors.New("JSON object is not terminated")
+		}
+		return nil
+	case '[':
+		for decoder.More() {
+			if err := consumeJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim(']') {
+			return errors.New("JSON array is not terminated")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unexpected JSON delimiter %q", delimiter)
+	}
+}

--- a/internal/sandboxsupervisor/framing_linux.go
+++ b/internal/sandboxsupervisor/framing_linux.go
@@ -1,0 +1,51 @@
+//go:build linux
+
+package sandboxsupervisor
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const maximumControlMessageSize = 64 << 10
+
+var errControlMessageTooLarge = errors.New("control message is too large")
+
+func readFrame(reader io.Reader) ([]byte, error) {
+	var header [4]byte
+	if _, err := io.ReadFull(reader, header[:]); err != nil {
+		return nil, fmt.Errorf("read control message length: %w", err)
+	}
+	length := binary.BigEndian.Uint32(header[:])
+	if length == 0 {
+		return nil, errors.New("control message is empty")
+	}
+	if length > maximumControlMessageSize {
+		return nil, fmt.Errorf("%w: length %d exceeds %d bytes", errControlMessageTooLarge, length, maximumControlMessageSize)
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(reader, payload); err != nil {
+		return nil, fmt.Errorf("read control message payload: %w", err)
+	}
+	return payload, nil
+}
+
+func writeFrame(writer io.Writer, payload []byte) error {
+	if len(payload) == 0 {
+		return errors.New("control message is empty")
+	}
+	if len(payload) > maximumControlMessageSize {
+		return fmt.Errorf("control message length %d exceeds %d bytes", len(payload), maximumControlMessageSize)
+	}
+	var header [4]byte
+	binary.BigEndian.PutUint32(header[:], uint32(len(payload)))
+	if _, err := writer.Write(header[:]); err != nil {
+		return fmt.Errorf("write control message length: %w", err)
+	}
+	if _, err := writer.Write(payload); err != nil {
+		return fmt.Errorf("write control message payload: %w", err)
+	}
+	return nil
+}

--- a/internal/sandboxsupervisor/protocol.go
+++ b/internal/sandboxsupervisor/protocol.go
@@ -1,0 +1,41 @@
+// Package sandboxsupervisor implements the closed local protocol between an
+// unprivileged Worker Node and the privileged Sandbox Supervisor.
+package sandboxsupervisor
+
+const (
+	RequestSchemaV1  = "sandbox-supervisor-request/v1"
+	ResponseSchemaV1 = "sandbox-supervisor-response/v1"
+
+	OperationCreateSandbox = "create_sandbox"
+)
+
+type ErrorCode string
+
+const (
+	ErrorCodeProfileNotFound      ErrorCode = "profile_not_found"
+	ErrorCodeUnsupportedVersion   ErrorCode = "unsupported_version"
+	ErrorCodeUnknownOperation     ErrorCode = "unknown_operation"
+	ErrorCodeMalformedRequest     ErrorCode = "malformed_request"
+	ErrorCodeInvalidReference     ErrorCode = "invalid_reference"
+	ErrorCodeRequestTooLarge      ErrorCode = "request_too_large"
+	ErrorCodeOperationUnavailable ErrorCode = "operation_unavailable"
+)
+
+type CreateSandboxRequest struct {
+	RequestID       string
+	SandboxID       string
+	ProfileIdentity string
+}
+
+type CreateSandboxResponse struct {
+	Schema    string
+	RequestID string
+	Result    *CreateSandboxResult
+	Error     *ProtocolError
+}
+
+type CreateSandboxResult struct{}
+
+type ProtocolError struct {
+	Code ErrorCode `json:"code"`
+}

--- a/internal/sandboxsupervisor/references.go
+++ b/internal/sandboxsupervisor/references.go
@@ -1,0 +1,37 @@
+package sandboxsupervisor
+
+import "strings"
+
+func profileDigest(identity string) (string, bool) {
+	const prefix = "sha256:"
+	if !strings.HasPrefix(identity, prefix) {
+		return "", false
+	}
+	digest := strings.TrimPrefix(identity, prefix)
+	if len(digest) != 64 {
+		return "", false
+	}
+	for _, character := range digest {
+		if character < '0' || character > '9' {
+			if character < 'a' || character > 'f' {
+				return "", false
+			}
+		}
+	}
+	return digest, true
+}
+
+func validOpaqueIdentifier(identifier string) bool {
+	if len(identifier) == 0 || len(identifier) > 64 {
+		return false
+	}
+	for index, character := range identifier {
+		lowercaseLetter := character >= 'a' && character <= 'z'
+		digit := character >= '0' && character <= '9'
+		if lowercaseLetter || digit || (index > 0 && (character == '-' || character == '_')) {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/sandboxsupervisor/roots_linux.go
+++ b/internal/sandboxsupervisor/roots_linux.go
@@ -1,0 +1,71 @@
+//go:build linux
+
+package sandboxsupervisor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func validateTrustedPaths(config ServerConfig) error {
+	if !filepath.IsAbs(config.SocketPath) || !filepath.IsAbs(config.ProfileStore) || !filepath.IsAbs(config.SandboxRoot) {
+		return errors.New("socket, Profile store, and Sandbox root paths must be absolute")
+	}
+	return validateSocketDirectory(filepath.Dir(config.SocketPath))
+}
+
+func validateSocketDirectory(directoryPath string) error {
+	if err := validateRuntimeOwnedRoot("socket directory", directoryPath); err != nil {
+		return err
+	}
+	info, err := os.Lstat(directoryPath)
+	if err != nil {
+		return fmt.Errorf("inspect socket directory: %w", err)
+	}
+	if permissions := info.Mode().Perm(); permissions != 0o750 {
+		return fmt.Errorf("socket directory permissions %04o must be 0750", permissions)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return errors.New("socket directory has no Linux ownership metadata")
+	}
+	if int(stat.Gid) != os.Getegid() {
+		return fmt.Errorf("socket directory group %d does not match Sandbox Supervisor GID %d", stat.Gid, os.Getegid())
+	}
+	return nil
+}
+
+func openRuntimeOwnedRoot(name, rootPath string) (*os.Root, error) {
+	if err := validateRuntimeOwnedRoot(name, rootPath); err != nil {
+		return nil, err
+	}
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", name, err)
+	}
+	return root, nil
+}
+
+func validateRuntimeOwnedRoot(name, rootPath string) error {
+	info, err := os.Lstat(rootPath)
+	if err != nil {
+		return fmt.Errorf("inspect %s: %w", name, err)
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s must be a real directory", name)
+	}
+	if permissions := info.Mode().Perm(); permissions&0o022 != 0 {
+		return fmt.Errorf("%s permissions %04o permit group or other writes", name, permissions)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("%s has no Linux ownership metadata", name)
+	}
+	if int(stat.Uid) != os.Geteuid() {
+		return fmt.Errorf("%s owner %d does not match Sandbox Supervisor UID %d", name, stat.Uid, os.Geteuid())
+	}
+	return nil
+}

--- a/internal/sandboxsupervisor/server_linux.go
+++ b/internal/sandboxsupervisor/server_linux.go
@@ -1,0 +1,194 @@
+//go:build linux
+
+package sandboxsupervisor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+	"path"
+	"sync"
+	"time"
+)
+
+type ServerConfig struct {
+	SocketPath   string
+	ProfileStore string
+	SandboxRoot  string
+}
+
+type requestEnvelope struct {
+	Schema     string          `json:"schema"`
+	RequestID  string          `json:"request_id"`
+	Operation  string          `json:"operation"`
+	Parameters json.RawMessage `json:"parameters"`
+}
+
+type createSandboxParameters struct {
+	SandboxID       string `json:"sandbox_id"`
+	ProfileIdentity string `json:"profile_identity"`
+}
+
+type responseEnvelope struct {
+	Schema    string               `json:"schema"`
+	RequestID string               `json:"request_id"`
+	Result    *CreateSandboxResult `json:"result,omitempty"`
+	Error     *ProtocolError       `json:"error,omitempty"`
+}
+
+type server struct {
+	profileStore *os.Root
+}
+
+const maximumConcurrentControlConnections = 16
+
+func Serve(ctx context.Context, config ServerConfig) error {
+	if err := validateTrustedPaths(config); err != nil {
+		return err
+	}
+	profileStore, err := openRuntimeOwnedRoot("Profile store", config.ProfileStore)
+	if err != nil {
+		return err
+	}
+	defer profileStore.Close()
+	sandboxRoot, err := openRuntimeOwnedRoot("Sandbox root", config.SandboxRoot)
+	if err != nil {
+		return err
+	}
+	defer sandboxRoot.Close()
+
+	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: config.SocketPath, Net: "unix"})
+	if err != nil {
+		return fmt.Errorf("listen on Sandbox Supervisor socket: %w", err)
+	}
+	listener.SetUnlinkOnClose(true)
+	defer listener.Close()
+	if err := os.Chmod(config.SocketPath, 0o660); err != nil {
+		return fmt.Errorf("restrict Sandbox Supervisor socket permissions: %w", err)
+	}
+
+	stopped := make(chan struct{})
+	defer close(stopped)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = listener.Close()
+		case <-stopped:
+		}
+	}()
+
+	service := &server{profileStore: profileStore}
+	connectionSlots := make(chan struct{}, maximumConcurrentControlConnections)
+	var handlers sync.WaitGroup
+	defer handlers.Wait()
+	for {
+		connection, err := listener.AcceptUnix()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("accept Sandbox Supervisor connection: %w", err)
+		}
+		select {
+		case connectionSlots <- struct{}{}:
+			handlers.Add(1)
+			go func() {
+				defer handlers.Done()
+				defer func() { <-connectionSlots }()
+				service.handle(connection)
+			}()
+		default:
+			_ = connection.Close()
+		}
+	}
+}
+
+func (service *server) handle(connection *net.UnixConn) {
+	defer connection.Close()
+	_ = connection.SetDeadline(time.Now().Add(5 * time.Second))
+
+	payload, err := readFrame(connection)
+	if err != nil {
+		if errors.Is(err, errControlMessageTooLarge) {
+			service.writeProtocolError(connection, "", ErrorCodeRequestTooLarge)
+		} else {
+			service.writeProtocolError(connection, "", ErrorCodeMalformedRequest)
+		}
+		return
+	}
+	var request requestEnvelope
+	if err := decodeStrictJSON(payload, &request, "schema", "request_id", "operation", "parameters"); err != nil {
+		service.writeProtocolError(connection, "", ErrorCodeMalformedRequest)
+		return
+	}
+	service.writeResponse(connection, service.responseForRequest(request))
+}
+
+func (service *server) responseForRequest(request requestEnvelope) responseEnvelope {
+	if request.Schema == "" || !validOpaqueIdentifier(request.RequestID) || request.Operation == "" || len(request.Parameters) == 0 {
+		return protocolErrorResponse(request.RequestID, ErrorCodeMalformedRequest)
+	}
+	if request.Schema != RequestSchemaV1 {
+		return protocolErrorResponse(request.RequestID, ErrorCodeUnsupportedVersion)
+	}
+	if request.Operation != OperationCreateSandbox {
+		return protocolErrorResponse(request.RequestID, ErrorCodeUnknownOperation)
+	}
+	return service.createSandboxResponse(request.RequestID, request.Parameters)
+}
+
+func (service *server) createSandboxResponse(requestID string, rawParameters json.RawMessage) responseEnvelope {
+	var parameters createSandboxParameters
+	if err := decodeStrictJSON(rawParameters, &parameters, "sandbox_id", "profile_identity"); err != nil || parameters.SandboxID == "" || parameters.ProfileIdentity == "" {
+		return protocolErrorResponse(requestID, ErrorCodeMalformedRequest)
+	}
+	if !validOpaqueIdentifier(parameters.SandboxID) {
+		return protocolErrorResponse(requestID, ErrorCodeInvalidReference)
+	}
+	digest, ok := profileDigest(parameters.ProfileIdentity)
+	if !ok {
+		return protocolErrorResponse(requestID, ErrorCodeInvalidReference)
+	}
+	profilePath := path.Join("sha256", digest)
+	profileInfo, err := service.profileStore.Lstat(profilePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return protocolErrorResponse(requestID, ErrorCodeProfileNotFound)
+		}
+		return protocolErrorResponse(requestID, ErrorCodeInvalidReference)
+	}
+	if profileInfo.Mode()&os.ModeSymlink != 0 || !profileInfo.IsDir() {
+		return protocolErrorResponse(requestID, ErrorCodeInvalidReference)
+	}
+	profile, err := service.profileStore.Open(profilePath)
+	if err != nil {
+		return protocolErrorResponse(requestID, ErrorCodeInvalidReference)
+	}
+	_ = profile.Close()
+
+	return protocolErrorResponse(requestID, ErrorCodeOperationUnavailable)
+}
+
+func (service *server) writeResponse(connection *net.UnixConn, response responseEnvelope) {
+	payload, err := json.Marshal(response)
+	if err != nil {
+		return
+	}
+	_ = writeFrame(connection, payload)
+}
+
+func (service *server) writeProtocolError(connection *net.UnixConn, requestID string, code ErrorCode) {
+	service.writeResponse(connection, protocolErrorResponse(requestID, code))
+}
+
+func protocolErrorResponse(requestID string, code ErrorCode) responseEnvelope {
+	return responseEnvelope{
+		Schema:    ResponseSchemaV1,
+		RequestID: requestID,
+		Error:     &ProtocolError{Code: code},
+	}
+}

--- a/tests/sandbox_supervisor_protocol_linux_test.go
+++ b/tests/sandbox_supervisor_protocol_linux_test.go
@@ -1,0 +1,747 @@
+//go:build linux
+
+package workspace_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/TH1NKING/Build-your-own-Docker-with-Go/internal/sandboxsupervisor"
+)
+
+func TestSandboxSupervisorClientReceivesStructuredProfileNotFound(t *testing.T) {
+	fixture := newSafeSandboxSupervisorFixture(t)
+	stopSupervisor := startSandboxSupervisor(t, fixture)
+	t.Cleanup(stopSupervisor)
+
+	requestContext, cancelRequest := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelRequest()
+
+	client := sandboxsupervisor.NewClient(fixture.socketPath)
+	response, err := client.CreateSandbox(requestContext, sandboxsupervisor.CreateSandboxRequest{
+		RequestID:       "req-001",
+		SandboxID:       "run-001",
+		ProfileIdentity: "sha256:" + strings.Repeat("0", 64),
+	})
+	if err != nil {
+		t.Fatal("request Sandbox creation through the public Supervisor client:", err)
+	}
+
+	if response.Schema != "sandbox-supervisor-response/v1" {
+		t.Fatalf("response schema = %q, want sandbox-supervisor-response/v1", response.Schema)
+	}
+	if response.RequestID != "req-001" {
+		t.Fatalf("response request ID = %q, want req-001", response.RequestID)
+	}
+	if response.Result != nil {
+		t.Fatalf("missing Profile unexpectedly produced a result: %#v", response.Result)
+	}
+	if response.Error == nil {
+		t.Fatal("missing Profile produced no structured protocol error")
+	}
+	if response.Error.Code != "profile_not_found" {
+		t.Fatalf(
+			"missing Profile error code = %q, want profile_not_found",
+			response.Error.Code,
+		)
+	}
+}
+
+func TestSandboxSupervisorRejectsUnsupportedProtocolVersion(t *testing.T) {
+	fixture := startEmptySandboxSupervisor(t)
+	responsePayload := exchangeSandboxSupervisorMessage(t, fixture.socketPath, []byte(`{
+  "schema": "sandbox-supervisor-request/v2",
+  "request_id": "req-version",
+  "operation": "create_sandbox",
+  "parameters": {
+    "sandbox_id": "run-001",
+    "profile_identity": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+  }
+}`))
+
+	var response struct {
+		Schema    string `json:"schema"`
+		RequestID string `json:"request_id"`
+		Result    any    `json:"result"`
+		Error     *struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(responsePayload, &response); err != nil {
+		t.Fatal("decode unsupported-version response:", err)
+	}
+	if response.Schema != "sandbox-supervisor-response/v1" || response.RequestID != "req-version" {
+		t.Fatalf("unsupported-version response identity = %#v", response)
+	}
+	if response.Result != nil {
+		t.Fatalf("unsupported protocol version unexpectedly produced a result: %#v", response.Result)
+	}
+	if response.Error == nil || response.Error.Code != "unsupported_version" {
+		t.Fatalf("unsupported protocol version response error = %#v, want unsupported_version", response.Error)
+	}
+}
+
+func TestSandboxSupervisorRejectsUnknownOperation(t *testing.T) {
+	fixture := startEmptySandboxSupervisor(t)
+	responsePayload := exchangeSandboxSupervisorMessage(t, fixture.socketPath, []byte(`{
+  "schema": "sandbox-supervisor-request/v1",
+  "request_id": "req-operation",
+  "operation": "run_host_command",
+  "parameters": {
+    "sandbox_id": "run-001",
+    "profile_identity": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+  }
+}`))
+
+	var response struct {
+		Schema    string `json:"schema"`
+		RequestID string `json:"request_id"`
+		Result    any    `json:"result"`
+		Error     *struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(responsePayload, &response); err != nil {
+		t.Fatal("decode unknown-operation response:", err)
+	}
+	if response.Schema != "sandbox-supervisor-response/v1" || response.RequestID != "req-operation" {
+		t.Fatalf("unknown-operation response identity = %#v", response)
+	}
+	if response.Result != nil {
+		t.Fatalf("unknown operation unexpectedly produced a result: %#v", response.Result)
+	}
+	if response.Error == nil || response.Error.Code != "unknown_operation" {
+		t.Fatalf("unknown operation response error = %#v, want unknown_operation", response.Error)
+	}
+}
+
+func TestSandboxSupervisorRejectsMalformedRequest(t *testing.T) {
+	fixture := startEmptySandboxSupervisor(t)
+	validProfileIdentity := "sha256:" + strings.Repeat("0", 64)
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{
+			name:    "truncated JSON",
+			payload: `{"schema":"sandbox-supervisor-request/v1"`,
+		},
+		{
+			name: "unknown host path field",
+			payload: `{
+  "schema":"sandbox-supervisor-request/v1",
+  "request_id":"req-unknown-field",
+  "operation":"create_sandbox",
+  "parameters":{"sandbox_id":"run-001","profile_identity":"` + validProfileIdentity + `"},
+  "workspace_path":"/etc"
+}`,
+		},
+		{
+			name: "unknown operation parameter",
+			payload: `{
+  "schema":"sandbox-supervisor-request/v1",
+  "request_id":"req-unknown-parameter",
+  "operation":"create_sandbox",
+  "parameters":{
+    "sandbox_id":"run-001",
+    "profile_identity":"` + validProfileIdentity + `",
+    "host_path":"/etc"
+  }
+}`,
+		},
+		{
+			name: "duplicate operation field",
+			payload: `{
+  "schema":"sandbox-supervisor-request/v1",
+  "request_id":"req-duplicate",
+  "operation":"create_sandbox",
+  "operation":"run_host_command",
+  "parameters":{"sandbox_id":"run-001","profile_identity":"` + validProfileIdentity + `"}
+}`,
+		},
+		{
+			name: "noncanonical envelope field case",
+			payload: `{
+  "schema":"sandbox-supervisor-request/v1",
+  "request_id":"req-field-case",
+  "Operation":"create_sandbox",
+  "parameters":{"sandbox_id":"run-001","profile_identity":"` + validProfileIdentity + `"}
+}`,
+		},
+		{
+			name: "case-variant semantic duplicate",
+			payload: `{
+  "schema":"sandbox-supervisor-request/v1",
+  "request_id":"req-case-duplicate",
+  "operation":"create_sandbox",
+  "Operation":"run_host_command",
+  "parameters":{"sandbox_id":"run-001","profile_identity":"` + validProfileIdentity + `"}
+}`,
+		},
+		{
+			name: "noncanonical parameter field case",
+			payload: `{
+  "schema":"sandbox-supervisor-request/v1",
+  "request_id":"req-parameter-case",
+  "operation":"create_sandbox",
+  "parameters":{"Sandbox_ID":"run-001","profile_identity":"` + validProfileIdentity + `"}
+}`,
+		},
+		{
+			name: "trailing JSON value",
+			payload: `{
+  "schema":"sandbox-supervisor-request/v1",
+  "request_id":"req-trailing",
+  "operation":"create_sandbox",
+  "parameters":{"sandbox_id":"run-001","profile_identity":"` + validProfileIdentity + `"}
+} {}`,
+		},
+		{
+			name: "missing parameters",
+			payload: `{
+  "schema":"sandbox-supervisor-request/v1",
+  "request_id":"req-missing",
+  "operation":"create_sandbox"
+}`,
+		},
+		{
+			name: "overlong request ID",
+			payload: `{
+  "schema":"sandbox-supervisor-request/v1",
+  "request_id":"` + strings.Repeat("r", 65) + `",
+  "operation":"create_sandbox",
+  "parameters":{"sandbox_id":"run-001","profile_identity":"` + validProfileIdentity + `"}
+}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			responsePayload := exchangeSandboxSupervisorMessage(t, fixture.socketPath, []byte(test.payload))
+			var response struct {
+				Schema string `json:"schema"`
+				Result any    `json:"result"`
+				Error  *struct {
+					Code string `json:"code"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(responsePayload, &response); err != nil {
+				t.Fatal("decode malformed-request response:", err)
+			}
+			if response.Schema != "sandbox-supervisor-response/v1" {
+				t.Fatalf("malformed-request response schema = %q", response.Schema)
+			}
+			if response.Result != nil {
+				t.Fatalf("malformed request unexpectedly produced a result: %#v", response.Result)
+			}
+			if response.Error == nil || response.Error.Code != "malformed_request" {
+				t.Fatalf("malformed request response error = %#v, want malformed_request", response.Error)
+			}
+		})
+	}
+}
+
+func TestSandboxSupervisorRejectsEscapingProfileReference(t *testing.T) {
+	fixture := startEmptySandboxSupervisor(t)
+	validProfileIdentity := "sha256:" + strings.Repeat("0", 64)
+	tests := []struct {
+		name            string
+		sandboxID       string
+		profileIdentity string
+	}{
+		{name: "absolute Profile path", sandboxID: "run-001", profileIdentity: "/etc"},
+		{name: "traversing Profile path", sandboxID: "run-001", profileIdentity: "../../outside"},
+		{name: "noncanonical Profile digest", sandboxID: "run-001", profileIdentity: "sha256:" + strings.Repeat("A", 64)},
+		{name: "traversing Sandbox ID", sandboxID: "../run-001", profileIdentity: validProfileIdentity},
+		{name: "backslash Sandbox ID", sandboxID: `run\outside`, profileIdentity: validProfileIdentity},
+		{name: "NUL Sandbox ID", sandboxID: "run\x00outside", profileIdentity: validProfileIdentity},
+		{name: "overlong Sandbox ID", sandboxID: strings.Repeat("a", 65), profileIdentity: validProfileIdentity},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			responsePayload := exchangeSandboxSupervisorMessage(
+				t,
+				fixture.socketPath,
+				createSandboxWireRequest(t, "req-reference", test.sandboxID, test.profileIdentity),
+			)
+			assertSandboxSupervisorErrorCode(t, responsePayload, "invalid_reference")
+		})
+	}
+
+	t.Run("Profile symlink escapes configured store", func(t *testing.T) {
+		digest := strings.Repeat("0", 64)
+		outsideProfile := t.TempDir()
+		profilePath := filepath.Join(fixture.profileStore, "sha256", digest)
+		if err := os.Symlink(outsideProfile, profilePath); err != nil {
+			t.Fatal("create escaping Profile symlink:", err)
+		}
+		responsePayload := exchangeSandboxSupervisorMessage(
+			t,
+			fixture.socketPath,
+			createSandboxWireRequest(t, "req-symlink", "run-001", "sha256:"+digest),
+		)
+		assertSandboxSupervisorErrorCode(t, responsePayload, "invalid_reference")
+	})
+}
+
+func TestSandboxSupervisorPublishesRestrictedUnixSocket(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Fatal("Sandbox Supervisor protocol acceptance must run as an unprivileged client")
+	}
+	fixture := startEmptySandboxSupervisor(t)
+
+	socketInfo, err := os.Lstat(fixture.socketPath)
+	if err != nil {
+		t.Fatal("stat published Sandbox Supervisor socket:", err)
+	}
+	if socketInfo.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("published Supervisor endpoint mode = %v, want Unix socket", socketInfo.Mode())
+	}
+	if permissions := socketInfo.Mode().Perm(); permissions != 0o660 {
+		t.Fatalf("Sandbox Supervisor socket permissions = %04o, want 0660", permissions)
+	}
+	socketStat, ok := socketInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("Sandbox Supervisor socket has no Linux ownership metadata")
+	}
+	if int(socketStat.Uid) != os.Geteuid() || int(socketStat.Gid) != os.Getegid() {
+		t.Fatalf(
+			"Sandbox Supervisor socket owner = %d:%d, want process owner %d:%d",
+			socketStat.Uid,
+			socketStat.Gid,
+			os.Geteuid(),
+			os.Getegid(),
+		)
+	}
+
+	directoryInfo, err := os.Stat(filepath.Dir(fixture.socketPath))
+	if err != nil {
+		t.Fatal("stat Sandbox Supervisor socket directory:", err)
+	}
+	if permissions := directoryInfo.Mode().Perm(); permissions != 0o750 {
+		t.Fatalf("Sandbox Supervisor socket directory permissions = %04o, want 0750", permissions)
+	}
+
+	responsePayload := exchangeSandboxSupervisorMessage(
+		t,
+		fixture.socketPath,
+		createSandboxWireRequest(t, "req-permissions", "run-001", "sha256:"+strings.Repeat("0", 64)),
+	)
+	assertSandboxSupervisorErrorCode(t, responsePayload, "profile_not_found")
+}
+
+func TestSandboxSupervisorRejectsOversizedRequest(t *testing.T) {
+	fixture := startEmptySandboxSupervisor(t)
+	responsePayload := exchangeSandboxSupervisorDeclaredFrame(t, fixture.socketPath, 64<<10+1, nil)
+	assertSandboxSupervisorErrorCode(t, responsePayload, "request_too_large")
+
+	recoveryResponse := exchangeSandboxSupervisorMessage(
+		t,
+		fixture.socketPath,
+		createSandboxWireRequest(t, "req-after-oversize", "run-001", "sha256:"+strings.Repeat("0", 64)),
+	)
+	assertSandboxSupervisorErrorCode(t, recoveryResponse, "profile_not_found")
+}
+
+func TestSandboxSupervisorPreservesUnexpectedSocketPathEntry(t *testing.T) {
+	commandPath := sandboxdCommandPath(t)
+
+	tests := []struct {
+		name   string
+		create func(t *testing.T, socketPath string) func(t *testing.T, socketPath string)
+	}{
+		{
+			name: "regular file",
+			create: func(t *testing.T, socketPath string) func(t *testing.T, socketPath string) {
+				if err := os.WriteFile(socketPath, []byte("sentinel"), 0o640); err != nil {
+					t.Fatal("create socket-path sentinel file:", err)
+				}
+				return func(t *testing.T, socketPath string) {
+					contents, err := os.ReadFile(socketPath)
+					if err != nil || string(contents) != "sentinel" {
+						t.Fatalf("socket-path sentinel after rejected start = %q, err=%v", contents, err)
+					}
+				}
+			},
+		},
+		{
+			name: "directory",
+			create: func(t *testing.T, socketPath string) func(t *testing.T, socketPath string) {
+				if err := os.Mkdir(socketPath, 0o750); err != nil {
+					t.Fatal("create directory at socket path:", err)
+				}
+				return func(t *testing.T, socketPath string) {
+					info, err := os.Stat(socketPath)
+					if err != nil || !info.IsDir() {
+						t.Fatalf("socket-path directory was not preserved: info=%#v err=%v", info, err)
+					}
+				}
+			},
+		},
+		{
+			name: "symlink",
+			create: func(t *testing.T, socketPath string) func(t *testing.T, socketPath string) {
+				target := filepath.Join(filepath.Dir(socketPath), "target")
+				if err := os.WriteFile(target, []byte("safe"), 0o640); err != nil {
+					t.Fatal("create socket symlink target:", err)
+				}
+				if err := os.Symlink(target, socketPath); err != nil {
+					t.Fatal("create symlink at socket path:", err)
+				}
+				return func(t *testing.T, socketPath string) {
+					gotTarget, err := os.Readlink(socketPath)
+					if err != nil || gotTarget != target {
+						t.Fatalf("socket-path symlink target = %q, want %q, err=%v", gotTarget, target, err)
+					}
+					contents, err := os.ReadFile(target)
+					if err != nil || string(contents) != "safe" {
+						t.Fatalf("socket symlink target after rejected start = %q, err=%v", contents, err)
+					}
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newSafeSandboxSupervisorFixture(t)
+			verify := test.create(t, fixture.socketPath)
+
+			assertSandboxdRejectsStartup(t, commandPath, fixture, 2*time.Second, "existing "+test.name)
+			verify(t, fixture.socketPath)
+		})
+	}
+}
+
+func TestSandboxSupervisorRejectsWritableRuntimeRoot(t *testing.T) {
+	commandPath := sandboxdCommandPath(t)
+
+	for _, rootName := range []string{"socket directory", "Profile store", "Sandbox root"} {
+		t.Run(rootName, func(t *testing.T) {
+			fixture := newSafeSandboxSupervisorFixture(t)
+			unsafeRoot := map[string]string{
+				"socket directory": filepath.Dir(fixture.socketPath),
+				"Profile store":    fixture.profileStore,
+				"Sandbox root":     fixture.sandboxRoot,
+			}[rootName]
+			if err := os.Chmod(unsafeRoot, 0o770); err != nil {
+				t.Fatalf("make %s group-writable: %v", rootName, err)
+			}
+
+			assertSandboxdRejectsStartup(t, commandPath, fixture, time.Second, "group-writable "+rootName)
+		})
+	}
+}
+
+func TestSandboxSupervisorRejectsSocketDirectoryWithoutWorkerAccess(t *testing.T) {
+	fixture := newSafeSandboxSupervisorFixture(t)
+	socketDirectory := filepath.Dir(fixture.socketPath)
+	if err := os.Chmod(socketDirectory, 0o700); err != nil {
+		t.Fatal("remove Worker group access from socket directory:", err)
+	}
+
+	assertSandboxdRejectsStartup(
+		t,
+		sandboxdCommandPath(t),
+		fixture,
+		time.Second,
+		"socket directory without Worker group access",
+	)
+}
+
+func TestSandboxSupervisorServesAnotherClientWhileRequestIsIncomplete(t *testing.T) {
+	fixture := startEmptySandboxSupervisor(t)
+	slowConnection, err := net.DialTimeout("unix", fixture.socketPath, 5*time.Second)
+	if err != nil {
+		t.Fatal("connect incomplete Sandbox Supervisor client:", err)
+	}
+	defer slowConnection.Close()
+	if _, err := slowConnection.Write([]byte{0, 0}); err != nil {
+		t.Fatal("write partial Sandbox Supervisor frame header:", err)
+	}
+
+	started := time.Now()
+	responsePayload := exchangeSandboxSupervisorMessage(
+		t,
+		fixture.socketPath,
+		createSandboxWireRequest(t, "req-concurrent", "run-001", "sha256:"+strings.Repeat("0", 64)),
+	)
+	if elapsed := time.Since(started); elapsed >= time.Second {
+		t.Fatalf("complete request waited %v behind an incomplete client, want under one second", elapsed)
+	}
+	assertSandboxSupervisorErrorCode(t, responsePayload, "profile_not_found")
+}
+
+func TestSandboxSupervisorDoesNotClaimSandboxCreationBeforeIsolationExists(t *testing.T) {
+	fixture := startEmptySandboxSupervisor(t)
+	digest := strings.Repeat("1", 64)
+	if err := os.Mkdir(filepath.Join(fixture.profileStore, "sha256", digest), 0o550); err != nil {
+		t.Fatal("create installed Profile fixture:", err)
+	}
+
+	responsePayload := exchangeSandboxSupervisorMessage(
+		t,
+		fixture.socketPath,
+		createSandboxWireRequest(t, "req-existing-profile", "run-001", "sha256:"+digest),
+	)
+	assertSandboxSupervisorErrorCode(t, responsePayload, "operation_unavailable")
+}
+
+func createSandboxWireRequest(t *testing.T, requestID, sandboxID, profileIdentity string) []byte {
+	t.Helper()
+
+	request := struct {
+		Schema     string `json:"schema"`
+		RequestID  string `json:"request_id"`
+		Operation  string `json:"operation"`
+		Parameters struct {
+			SandboxID       string `json:"sandbox_id"`
+			ProfileIdentity string `json:"profile_identity"`
+		} `json:"parameters"`
+	}{
+		Schema:    "sandbox-supervisor-request/v1",
+		RequestID: requestID,
+		Operation: "create_sandbox",
+	}
+	request.Parameters.SandboxID = sandboxID
+	request.Parameters.ProfileIdentity = profileIdentity
+	payload, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal("encode raw Sandbox creation request:", err)
+	}
+	return payload
+}
+
+func assertSandboxSupervisorErrorCode(t *testing.T, responsePayload []byte, wantCode string) {
+	t.Helper()
+
+	var response struct {
+		Result any `json:"result"`
+		Error  *struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(responsePayload, &response); err != nil {
+		t.Fatal("decode Sandbox Supervisor error response:", err)
+	}
+	if response.Result != nil {
+		t.Fatalf("rejected Sandbox Supervisor request unexpectedly produced a result: %#v", response.Result)
+	}
+	if response.Error == nil || response.Error.Code != wantCode {
+		t.Fatalf("Sandbox Supervisor error = %#v, want %s", response.Error, wantCode)
+	}
+}
+
+type sandboxSupervisorFixture struct {
+	socketPath   string
+	profileStore string
+	sandboxRoot  string
+}
+
+func shortSandboxSupervisorTemporaryDirectory(t *testing.T) string {
+	t.Helper()
+
+	directory, err := os.MkdirTemp("", "sd-")
+	if err != nil {
+		t.Fatal("create short Sandbox Supervisor temporary directory:", err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(directory); err != nil {
+			t.Errorf("remove Sandbox Supervisor temporary directory %q: %v", directory, err)
+		}
+	})
+	return directory
+}
+
+func newSafeSandboxSupervisorFixture(t *testing.T) sandboxSupervisorFixture {
+	t.Helper()
+
+	temporaryDirectory := shortSandboxSupervisorTemporaryDirectory(t)
+	fixture := sandboxSupervisorFixture{
+		socketPath:   filepath.Join(temporaryDirectory, "run", "sandboxd.sock"),
+		profileStore: filepath.Join(temporaryDirectory, "profiles"),
+		sandboxRoot:  filepath.Join(temporaryDirectory, "sandboxes"),
+	}
+	for _, directory := range []string{
+		filepath.Dir(fixture.socketPath),
+		filepath.Join(fixture.profileStore, "sha256"),
+		fixture.sandboxRoot,
+	} {
+		if err := os.MkdirAll(directory, 0o750); err != nil {
+			t.Fatalf("create Sandbox Supervisor fixture directory %q: %v", directory, err)
+		}
+	}
+	return fixture
+}
+
+func startEmptySandboxSupervisor(t *testing.T) sandboxSupervisorFixture {
+	t.Helper()
+
+	fixture := newSafeSandboxSupervisorFixture(t)
+	stopSupervisor := startSandboxSupervisor(t, fixture)
+	t.Cleanup(stopSupervisor)
+	return fixture
+}
+
+func exchangeSandboxSupervisorMessage(t *testing.T, socketPath string, requestPayload []byte) []byte {
+	t.Helper()
+
+	return exchangeSandboxSupervisorDeclaredFrame(t, socketPath, uint32(len(requestPayload)), requestPayload)
+}
+
+func exchangeSandboxSupervisorDeclaredFrame(
+	t *testing.T,
+	socketPath string,
+	declaredLength uint32,
+	payload []byte,
+) []byte {
+	t.Helper()
+
+	connection, err := net.DialTimeout("unix", socketPath, 5*time.Second)
+	if err != nil {
+		t.Fatal("connect to Sandbox Supervisor socket:", err)
+	}
+	defer connection.Close()
+	if err := connection.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatal("set raw Sandbox Supervisor request deadline:", err)
+	}
+
+	var header [4]byte
+	binary.BigEndian.PutUint32(header[:], declaredLength)
+	if _, err := connection.Write(header[:]); err != nil {
+		t.Fatal("write declared Sandbox Supervisor request length:", err)
+	}
+	if len(payload) > 0 {
+		if _, err := connection.Write(payload); err != nil {
+			t.Fatal("write declared Sandbox Supervisor request payload:", err)
+		}
+	}
+
+	if _, err := io.ReadFull(connection, header[:]); err != nil {
+		t.Fatal("read Sandbox Supervisor response length:", err)
+	}
+	responseLength := binary.BigEndian.Uint32(header[:])
+	if responseLength == 0 || responseLength > 64<<10 {
+		t.Fatalf("Sandbox Supervisor response length = %d, want 1..65536", responseLength)
+	}
+	responsePayload := make([]byte, responseLength)
+	if _, err := io.ReadFull(connection, responsePayload); err != nil {
+		t.Fatal("read Sandbox Supervisor response payload:", err)
+	}
+	return responsePayload
+}
+
+func sandboxdCommandPath(t *testing.T) string {
+	t.Helper()
+
+	commandPath := os.Getenv("SANDBOXD_CLI")
+	if commandPath != "" {
+		return commandPath
+	}
+
+	commandPath = filepath.Join(t.TempDir(), "sandboxd")
+	build := exec.Command("go", "build", "-o", commandPath, "./cmd/sandboxd")
+	build.Dir = repositoryRoot(t)
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build public sandboxd command: %v\n%s", err, output)
+	}
+	return commandPath
+}
+
+func assertSandboxdRejectsStartup(
+	t *testing.T,
+	commandPath string,
+	fixture sandboxSupervisorFixture,
+	timeout time.Duration,
+	reason string,
+) {
+	t.Helper()
+
+	commandContext, cancelCommand := context.WithTimeout(context.Background(), timeout)
+	defer cancelCommand()
+	command := exec.CommandContext(
+		commandContext,
+		commandPath,
+		"--socket", fixture.socketPath,
+		"--profile-store", fixture.profileStore,
+		"--sandbox-root", fixture.sandboxRoot,
+	)
+	if output, err := command.CombinedOutput(); err == nil {
+		t.Fatalf("sandboxd accepted %s\n%s", reason, output)
+	} else if errors.Is(commandContext.Err(), context.DeadlineExceeded) {
+		t.Fatalf("sandboxd did not reject %s before serving\n%s", reason, output)
+	}
+}
+
+func startSandboxSupervisor(t *testing.T, fixture sandboxSupervisorFixture) func() {
+	t.Helper()
+
+	commandPath := sandboxdCommandPath(t)
+
+	var output bytes.Buffer
+	command := exec.Command(
+		commandPath,
+		"--socket", fixture.socketPath,
+		"--profile-store", fixture.profileStore,
+		"--sandbox-root", fixture.sandboxRoot,
+	)
+	command.Stdout = &output
+	command.Stderr = &output
+	if err := command.Start(); err != nil {
+		t.Fatal("start public sandboxd command:", err)
+	}
+
+	exited := make(chan error, 1)
+	go func() {
+		exited <- command.Wait()
+	}()
+
+	startupDeadline := time.Now().Add(5 * time.Second)
+	for {
+		info, err := os.Lstat(fixture.socketPath)
+		if err == nil && info.Mode()&os.ModeSocket != 0 {
+			break
+		}
+		select {
+		case err := <-exited:
+			t.Fatalf("sandboxd exited before publishing its Unix socket: %v\n%s", err, output.String())
+		default:
+		}
+		if time.Now().After(startupDeadline) {
+			_ = command.Process.Kill()
+			<-exited
+			t.Fatalf("sandboxd did not publish its Unix socket within five seconds\n%s", output.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return func() {
+		if err := command.Process.Signal(os.Interrupt); err != nil {
+			t.Errorf("stop sandboxd: %v", err)
+			return
+		}
+		select {
+		case err := <-exited:
+			if err != nil {
+				t.Errorf("sandboxd exited after interrupt: %v\n%s", err, output.String())
+			}
+		case <-time.After(5 * time.Second):
+			_ = command.Process.Kill()
+			<-exited
+			t.Errorf("sandboxd did not stop within five seconds\n%s", output.String())
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- add the Linux `sandboxd` command and a versioned, length-prefixed Unix socket protocol
- enforce a closed `create_sandbox` operation, strict JSON, bounded messages, trusted roots, and opaque references
- document the v1 contract and add non-root Linux protocol acceptance coverage

## Testing

- Linux: formatting, `go vet ./...`, `go test ./...`, `go build ./...`, and `bash -n with_shell/*.sh`
- Windows: `go test ./...`
- two-axis Standards and Spec review: 0 remaining findings

Closes #9
