### PR TITLE
feat: create mapped read-only Sandboxes with pivot_root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,19 @@ jobs:
             "$RUNNER_TEMP/profile-bundle-tests" \
             -test.v \
             -test.run='^(TestProfileBundleInstall|TestPythonDataV1Production)'
+
+  sandbox-creation:
+    name: Sandbox creation (real Linux kernel)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Verify Sandbox identity and root isolation
+        run: bash tests/run-sandbox-creation-linux.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build check fmt-check shell-check test vet
+.PHONY: build check fmt-check shell-check test test-sandbox-creation vet
 
 GO_FILES := $(shell find . -type f -name '*.go' -not -path './.git/*' -not -path './.cache/*')
 
@@ -23,3 +23,7 @@ build:
 
 shell-check:
 	bash -n with_shell/*.sh
+	bash -n tests/run-sandbox-creation-linux.sh
+
+test-sandbox-creation:
+	bash tests/run-sandbox-creation-linux.sh

--- a/README.md
+++ b/README.md
@@ -50,7 +50,15 @@ GitHub Actions 会在 Ubuntu 上对 push 和 pull request 执行同一个 `make 
 
 Profile Bundle 另有一个 Linux root 验收 job：它校验锁定下载、两次可复现构建、root-owned 原子安装、恶意 Bundle 拒绝以及真实 CPython 内容 smoke。格式和命令合同见 [`docs/profile-bundle-v1.md`](docs/profile-bundle-v1.md)。
 
-Sandbox Supervisor 协议测试必须以普通 Linux 用户运行，通过真实 Unix socket 验证版本、封闭 operation 集合、严格消息解析、受信路径和权限边界；协议与 `sandboxd` 启动合同见 [`docs/sandbox-supervisor-protocol-v1.md`](docs/sandbox-supervisor-protocol-v1.md)。真实 User Namespace、`pivot_root` 和 Sandbox 创建属于后续实现，T03 不会返回虚假的创建成功。
+Sandbox Supervisor 协议测试必须以普通 Linux 用户运行，通过真实 Unix socket 验证版本、封闭 operation 集合、严格消息解析、受信路径和权限边界。T04 已实现创建真实 Sandbox：配置预留的 subordinate UID/GID 后，`sandboxd` 建立独立 user/mount/PID/network namespace，将 Runtime Profile 作为只读私有根挂载，通过 `pivot_root` 脱离旧根，再返回 `sandbox_id`。三个 subordinate-ID 参数全部为零时保留仅验证协议的模式，创建仍返回 `operation_unavailable`。配置与协议合同见 [`docs/sandbox-supervisor-protocol-v1.md`](docs/sandbox-supervisor-protocol-v1.md)。
+
+在已安装 Go、`sudo` 和 util-linux 的专用、可丢弃 Linux 环境中，以普通用户运行真实创建验收：
+
+```sh
+bash tests/run-sandbox-creation-linux.sh
+```
+
+这个入口构建工具和可信测试探针，再在隔离的 Linux 测试环境中验证身份映射、只读根、旧宿主根不可达和描述符边界。探针由测试端通过 `nsenter` 启动；它不是产品执行接口，也不代表已经执行真实 Python。当前 Sandbox 内只有等待中的可信 bootstrap PID 1；T05 的 Sandbox Init、T06 的完整故障清理和后续安全强化仍未完成，尚不能用于不可信 Workload。实现原理、取舍和实验说明见 [`T04 学习笔记`](docs/learning/t04-sandbox-creation.md)。
 
 ## 使用 Go Runtime Lab
 

--- a/cmd/sandboxd/main_linux.go
+++ b/cmd/sandboxd/main_linux.go
@@ -22,6 +22,9 @@ func main() {
 }
 
 func run(arguments []string) error {
+	if len(arguments) == 1 && arguments[0] == "--sandbox-bootstrap" {
+		return sandboxsupervisor.RunBootstrap()
+	}
 	flags := flag.NewFlagSet("sandboxd", flag.ContinueOnError)
 	flags.SetOutput(os.Stderr)
 
@@ -29,6 +32,9 @@ func run(arguments []string) error {
 	flags.StringVar(&config.SocketPath, "socket", "", "absolute path for the restricted Worker socket")
 	flags.StringVar(&config.ProfileStore, "profile-store", "", "absolute path to the root-owned Profile store")
 	flags.StringVar(&config.SandboxRoot, "sandbox-root", "", "absolute path to the runtime-owned Sandbox root")
+	flags.UintVar(&config.SubUIDStart, "subuid-start", 0, "first operator-reserved subordinate host UID")
+	flags.UintVar(&config.SubGIDStart, "subgid-start", 0, "first operator-reserved subordinate host GID")
+	flags.UintVar(&config.SubIDCount, "subid-count", 0, "reserved IDs per UID/GID range, in blocks of 65536; zero disables creation")
 	if err := flags.Parse(arguments); err != nil {
 		return err
 	}

--- a/docs/learning/t04-sandbox-creation.md
+++ b/docs/learning/t04-sandbox-creation.md
@@ -1,0 +1,101 @@
+# T04：从一条创建请求到真实 Linux Sandbox
+
+这次交付让 `create_sandbox` 第一次能够返回有内核隔离支撑的成功结果。`sandboxd` 会创建一个活着的可信进程，把它放入独立 namespace，并让它的 `/` 指向只读 Runtime Profile。客户端只拿到 `sandbox_id`。
+
+当前是完整系统规格中的一个阶段。这个进程只等待退出，不接受 Workload；T05 的 Sandbox Init 和执行协议、T06 的完整故障清理，以及 T07–T12 对应的后续隔离与资源约束仍需完成。测试通过不等于现在可以安全运行任意 AI 生成代码。
+
+## 先看一次创建经过什么
+
+```mermaid
+flowchart TD
+    A[普通 Worker：sandbox_id + profile_identity] --> B[sandboxd：验证封闭协议与可信 Profile]
+    B --> C[预留独占的 subordinate UID/GID block]
+    C --> D[创建 user / mount / PID / network namespace]
+    D --> E[可信 bootstrap 成为内部 PID 1 / UID 0]
+    E --> F[私有挂载传播 + 只读 Profile 根]
+    F --> G[pivot_root + 脱离旧根 + 关闭 Profile FD]
+    G --> H[通过私有管道报告 ready]
+    H --> I[返回 sandbox_id；PID 1 等待生命周期管道结束]
+```
+
+关键顺序是先确认隔离完成，再报告成功。创建子进程本身不代表挂载成功；bootstrap 若在切根过程中失败或没有及时报告 ready，Supervisor 返回 `creation_failed`，并回收这次创建占用的资源。
+
+公开协议仍然只有 `create_sandbox`。客户端不能传 `/home/...` 这样的宿主路径，不能指定 UID、挂载参数或一段 shell。可信 Supervisor 自己根据 Runtime Profile 的摘要定位目录。这保留了 T03 的权限边界，也使新增能力容易审计。
+
+## User Namespace：内部 root 对应谁
+
+测试中的一个映射是：
+
+```text
+uid_map: 0 200000 65536
+gid_map: 0 300000 65536
+
+内部 UID 0       → 宿主 UID 200000
+内部 UID 1000    → 宿主 UID 201000
+内部 UID 65535   → 宿主 UID 265535
+```
+
+三个数字分别是内部起点、外部起点、数量。User Namespace 让内部 UID 0 能完成该 namespace 管辖的初始化操作，同时不把它映射成宿主 UID 0；它不会创建一个新的 Linux 内核。权限的作用范围与身份映射需要一起理解。参见 [user_namespaces(7)](https://man7.org/linux/man-pages/man7/user_namespaces.7.html)。
+
+实现给每个活跃 Sandbox 分配独占的 65,536 个 UID 和 GID。好处是多个 Sandbox 的内部 UID 1000 不会落到同一个宿主身份；代价是需要管理足够大的预留范围，数量耗尽时必须拒绝创建。固定让所有 Sandbox 共用一段范围更省配置，但会让宿主文件权限难以区分它们。
+
+这也不等于整个系统已经 rootless：本项目由宿主 root 运行 `sandboxd` 完成特权操作，Worker 才是普通进程。三个启动参数 `--subuid-start`、`--subgid-start`、`--subid-count` 声明 Platform Operator 已预留的范围；程序不读取或修改 `/etc/subuid` 和 `/etc/subgid`。预留必须避开系统账户、其他 Supervisor 和其他容器工具的分配。测试里的数字仅用于可丢弃环境，不能直接当成部署建议。
+
+## 为什么不是只做 chroot
+
+| 方法 | 解决的问题 | 单独使用的局限 |
+| --- | --- | --- |
+| `chroot` | 改变路径解析使用的根目录 | 不关闭已有 FD，也不自动改变当前目录；不建立身份、进程或网络隔离 |
+| Mount Namespace | 提供独立的挂载视图 | 刚创建时仍带着旧挂载树，需要显式处理传播和旧根 |
+| `pivot_root` + 卸载旧根 | 把新挂载切为根，并脱离旧挂载树 | 不处理身份、系统调用许可、资源消耗，也不自动关闭旧文件句柄 |
+| User / PID / Network Namespace | 分别隔离身份、进程编号和网络视图 | 仍共享内核，且每类 namespace 只负责自己的那一部分 |
+
+`chroot` 很适合构建环境或路径布局实验；其手册明确说明它不是一个完整的安全沙箱机制。这里需要同时整理挂载树和身份，所以组合多个原语。参见 [chroot(2)](https://man7.org/linux/man-pages/man2/chroot.2.html)。
+
+切根前，bootstrap 先把挂载传播设为递归 private，避免自己的挂载操作影响宿主或接收宿主后续传播。它在独立 namespace 的临时 tmpfs 中创建挂载点，再用非递归 bind 引入 Profile，避免顺带带入 Profile 下的其他宿主挂载。根挂载最终为只读，附带 `nosuid`、`nodev`，并保留适用的原有挂载限制。
+
+常见 `pivot_root(new_root, put_old)` 用法需要在新根中准备旧根目录。这里 Profile 已经不可变，使用手册记录的 `pivot_root(".", ".")` 写法：把旧根暂时叠在当前位置，再 `umount2(".", MNT_DETACH)` 脱离，最后 `chdir("/")`。这样不用为了初始化去修改 Profile。`MNT_DETACH` 移除挂载关联，不会消灭外部仍持有的引用，所以关闭旧 FD 仍是独立步骤。参见 [pivot_root(2)](https://man7.org/linux/man-pages/man2/pivot_root.2.html)。
+
+## 三个容易被忽略的实现细节
+
+第一个是如何进入受保护目录。Profile store 的宿主祖先目录可能是 `0700`；内部 root 映射成 subordinate UID 后，重新按宿主绝对路径找它会因权限不足失败。随手给目录放宽权限会改变安装边界。
+
+实现先在 Supervisor 中逐级打开 `sha256/<digest>/rootfs`，拒绝符号链接并核对 root 所有权和安装模式。然后锁住一个 OS 线程，通过 `unshare(CLONE_FS)` 分离它的当前目录状态，用已打开的 FD 进入 Profile，再启动子进程。创建 Mount Namespace 时，继承的当前目录会进入新挂载视图；已打开 FD 则仍引用原来的挂载，因此 bootstrap 用继承的当前目录作为 bind 来源，用 FD 核对身份后关闭它。该线程退出后由 Go 回收，不让修改过的当前目录泄漏给服务的其他工作线程。参见 [unshare(2)](https://man7.org/linux/man-pages/man2/unshare.2.html) 和 [Go 的 LockOSThread](https://pkg.go.dev/runtime#LockOSThread)。
+
+第二个是运行时自己的文件句柄。应用代码没主动打开宿主文件，不代表运行时也没有。Go 的容器感知并行度逻辑可能保留宿主 cgroup 文件。本次为可信 bootstrap 设置 `GOMAXPROCS=1`、`GODEBUG=containermaxprocs=0,updatemaxprocs=0`，避免这些探测与更新留下宿主 FD；测试再从 `/proc/<pid>/fd` 检查实际结果。这只限制可信 bootstrap 的 Go 并行度，不是 Workload CPU 配额。环境参数说明见 [Go runtime 文档](https://pkg.go.dev/runtime)。
+
+第三个来自代码审查：如果启动 shell 用 `9</某个宿主目录` 把 FD 9 传给 `sandboxd`，Go 的 `ExtraFiles` 不会自动阻止它继续传给子进程。回归测试实际复现了这个泄漏。现在 Supervisor 启动时将非标准继承 FD 标记为 `CLOEXEC`，让下一次 `exec` 关闭它们，再显式传递需要的私有句柄。这样不会像粗暴关闭所有 FD 那样破坏 Go 的内部事件机制。子进程的诊断输出也经过管道转发，避免拿到 Supervisor 的宿主日志文件句柄。
+
+## 五分钟实验：先复现证据
+
+前提是已准备专用、可丢弃的 Linux 环境、符合 `go.mod` 的 Go、`sudo` 和 util-linux（提供 `unshare`、`nsenter`）。在该环境的仓库根目录，以普通用户运行；首次下载 Go 工具链或依赖可能超过五分钟。
+
+```sh
+# 普通用户验收真实 Unix socket 协议。
+go test ./tests -run '^TestSandboxSupervisor' -count=1
+
+# 构建工具后，在隔离的 mount/PID/network 测试环境中运行创建验收。
+bash tests/run-sandbox-creation-linux.sh
+```
+
+第二条脚本会在需要时调用 `sudo`，也可以由已有 root 账户运行；第一条协议测试必须是普通用户。脚本构建 `sandboxd`、`profile-bundle`、`sandbox-root-probe` 和带 `sandbox_root,profilebundle_root` 标签的测试程序，并通过绝对路径变量 `SANDBOXD_CLI`、`PROFILE_BUNDLE_CLI`、`SANDBOX_ROOT_PROBE` 交给测试。临时 Profile 与 Sandbox 都属于测试夹具。
+
+若已为目标 Linux 环境交叉编译，可以设置 `SANDBOX_TEST_BIN_DIR` 为该环境中四个同名二进制所在的绝对目录，再运行脚本。例如 `/opt/t04-test-bin` 必须先实际包含上述四个文件；不要把 Windows 盘符路径直接传进 Linux。日常实验无需设置此变量。
+
+读测试时重点寻找以下证据：
+
+- `/proc/<pid>/uid_map` 和 `gid_map` 精确匹配配置；没有继承宿主附加组。
+- user、mount、PID、network namespace 与测试宿主不同。
+- Sandbox 的 mountinfo 中只剩私有只读根；没有旧根挂载。
+- ready 之后没有指向宿主目录或普通文件的 FD。
+- 可信探针读取宿主专属标记得到 `ENOENT`，尝试写根目录得到 `EROFS`；宿主标记和宿主挂载的可写状态保持正常。
+
+探针成功时内部输出 `host-root-unreachable; profile-read-only`，测试会核对它。探针是 Go 测试程序，刻意安装到夹具的 `/opt/python/bin/python3`；不是 CPython。它由拥有权限的测试端用 `nsenter` 进入 Sandbox 启动，`sandboxd` 没有为测试增加执行后门。
+
+这些测试说明上述内核行为在实际测试环境成立。它们没有证明能执行 Python、能抵抗任意内核漏洞、能限制 fork/内存/CPU，或能在任意崩溃后回收完整 Workload。当前只保证创建阶段与空闲可信进程的基础收尾；后续功能仍按原有票据与 ADR 实现。
+
+## 建议自己讲一遍
+
+不看代码，尝试回答：“内部 UID 0 为什么不是宿主 root？为什么只读根仍然要关闭 FD？为什么报告 ready 要等到 `pivot_root` 之后？为什么测试能用 `nsenter`，产品却没有执行接口？”
+
+能解释这些问题后，再读 [`creation_linux.go`](../../internal/sandboxsupervisor/creation_linux.go) 的创建流程、[`bootstrap_linux.go`](../../internal/sandboxsupervisor/bootstrap_linux.go) 的根切换，以及 [`sandbox_creation_linux_test.go`](../../tests/sandbox_creation_linux_test.go) 的外部验收。你会看到每个操作都对应一个可观察的边界，而后续 T05 会在这个已经建立的环境中实现真正的 Execution。

--- a/docs/sandbox-supervisor-protocol-v1.md
+++ b/docs/sandbox-supervisor-protocol-v1.md
@@ -5,10 +5,10 @@ unprivileged Worker Node and the privileged `sandboxd` process. It is available
 only on Linux and does not expose shell commands, arbitrary host paths, mount
 operations, process identifiers, or caller-selected isolation settings.
 
-This version establishes the transport and validation boundary required by
-T03. T04 implements actual Sandbox creation. Until then, a valid
-`create_sandbox` request whose Profile exists returns `operation_unavailable`
-instead of claiming that an isolated Sandbox was created.
+T03 establishes the transport and validation boundary. T04 adds actual
+Sandbox creation when the Platform Operator enables subordinate-ID allocation.
+The default protocol-only mode still returns `operation_unavailable` for a
+valid `create_sandbox` request whose Profile exists.
 
 ## Trusted startup configuration
 
@@ -31,6 +31,32 @@ it.
 
 `sandboxd` refuses to overwrite a pre-existing file, directory, symlink, or
 active socket at the configured socket path.
+
+Creation additionally requires trusted startup configuration:
+
+```text
+--subuid-start <first-reserved-host-uid>
+--subgid-start <first-reserved-host-gid>
+--subid-count <reserved-ids-in-each-range>
+```
+
+All three values default to zero. All-zero configuration disables creation
+and permits the existing unprivileged protocol tests. Otherwise, `sandboxd`
+must run as root, both starts must be nonzero, and the count must be a positive
+multiple of 65,536. The complete ranges must fit in usable Linux UID/GID
+space; neither host ID zero nor the reserved ID `4294967295` is mapped.
+
+Each active Sandbox reserves a distinct block of 65,536 IDs from each range.
+Internal IDs `0..65535` map to that block; concurrent Sandboxes managed by the
+same Supervisor never share a block. A count of 131,072 therefore permits two
+active Sandboxes. Supplementary host groups are cleared during child startup.
+
+The Platform Operator must reserve these ranges against system accounts,
+other Supervisor instances, and other subordinate-ID users before startup.
+`sandboxd` does not read or update `/etc/subuid` or `/etc/subgid`, or detect
+external allocations. The flags declare an already-reserved allocation;
+they do not make arbitrary host IDs safe to use. The request protocol cannot
+override any of these settings.
 
 ## Framing
 
@@ -100,8 +126,84 @@ Stable v1 error codes are:
 - `request_too_large`
 - `profile_not_found`
 - `operation_unavailable`
+- `creation_failed`
+- `sandbox_exists`
+- `identity_range_exhausted`
+
+`creation_failed` means the Supervisor could not complete or confirm the
+private bootstrap. `sandbox_exists` rejects an active or pre-existing Sandbox
+identifier without replacing it. `identity_range_exhausted` means all
+configured subordinate-ID blocks are reserved by active creations or Sandboxes.
 
 Errors do not echo raw malformed input or configured host paths.
+
+A successful creation returns only the opaque Sandbox identifier:
+
+```json
+{
+  "schema": "sandbox-supervisor-response/v1",
+  "request_id": "req-001",
+  "result": {
+    "sandbox_id": "run-001"
+  }
+}
+```
+
+The response exposes no host PID, path, UID/GID allocation, or private
+bootstrap channel. A successful response means that the trusted bootstrap
+reported completion of root setup; it does not promise indefinite liveness
+or that a Workload can execute.
+
+## Creation and lifetime boundary
+
+The Supervisor opens the selected root-owned, immutable Profile through its
+trusted Profile store. It opens each `sha256/<digest>/rootfs` component without
+following symlinks and checks root ownership and the installer's exact modes:
+`0755` for `sha256`, `0555` for the Profile directory and root filesystem.
+It re-executes its own binary in new user, mount, PID,
+and network namespaces. This private bootstrap accepts inherited handles,
+not caller paths or commands. It runs as namespace PID 1 and internal UID 0,
+which maps to the allocated non-root host ID.
+
+The bootstrap makes mount propagation recursively private, mounts temporary
+staging inside its own namespace, and non-recursively bind-mounts the Profile
+root. The new root is remounted read-only with `nosuid` and `nodev`, preserving
+applicable existing mount restrictions. `pivot_root(".", ".")` followed by
+detaching the old root needs no writable `put_old` directory in the immutable
+Profile. The temporary staging disappears with the detached old root.
+
+The Supervisor starts the child from an already-open Profile directory on a
+locked OS thread with an unshared `CLONE_FS` context. The inherited current
+directory is translated into the child's mount namespace. This avoids
+resolving protected host ancestors under subordinate credentials, and avoids
+using an inherited directory descriptor as a bind source in the parent mount
+namespace. The Supervisor's other threads keep their own current directory.
+The child checks its current directory against the supplied Profile handle
+and closes that handle before reporting readiness.
+
+The private bootstrap environment sets `GOMAXPROCS=1` and
+`GODEBUG=containermaxprocs=0,updatemaxprocs=0` so the Go runtime does not retain
+host cgroup file descriptors while discovering or updating CPU parallelism.
+This is descriptor hygiene, not a Workload Resource Budget. Readiness leaves
+no host directory or regular-file descriptors in the trusted bootstrap;
+private pipes and runtime event descriptors remain.
+
+Before serving, the Supervisor marks inherited descriptors above standard I/O
+close-on-exec. This includes descriptors supplied by a shell or service manager;
+Go's `ExtraFiles` alone is not an inheritance whitelist. The child receives
+only explicitly remapped private handles, and diagnostics always use a pipe
+even when the Supervisor's stderr is a host log file. The Supervisor's own
+runtime descriptors are marked, not forcibly closed.
+
+T04 leaves this trusted PID 1 idle on a lifetime-only pipe. There is no
+Execution operation, shell, or caller-controlled executable. The T05 Sandbox
+Init contract, including sequential Executions and child reaping, is not yet
+implemented. Graceful Supervisor shutdown terminates and waits for its idle
+Sandboxes; creation failures release resources acquired by that attempt, and
+loss of the lifetime pipe causes the idle bootstrap to exit. This is not the
+full T06 lifecycle, restart recovery, or cleanup guarantee for Workloads.
+Workspace mounts, capability reduction, System Call Policy enforcement, and
+Resource Budgets remain subsequent work.
 
 ## Verification
 
@@ -115,3 +217,24 @@ go test ./tests -run '^TestSandboxSupervisor' -count=1
 The suite launches the real `sandboxd` command and communicates over a real
 Unix socket. It fails if the client process is root and does not grant the
 client mount, namespace, or cgroup privileges.
+
+Run the separate privileged creation suite from an ordinary account inside
+a disposable Linux VM, with Go, `sudo`, and util-linux installed:
+
+```sh
+bash tests/run-sandbox-creation-linux.sh
+```
+
+The script builds the Supervisor, Profile installer, and trusted conformance
+probe, then runs tests tagged `sandbox_root,profilebundle_root` in an outer
+mount/PID/network namespace with a private proc mount. It supplies absolute
+paths through `SANDBOXD_CLI`, `PROFILE_BUNDLE_CLI`, and `SANDBOX_ROOT_PROBE`.
+Test allocations are fixture values for the disposable environment, not
+deployment recommendations.
+
+The harness observes real `/proc` mappings, mount topology and descriptors,
+and uses host-side `nsenter` to execute the trusted probe inside the Sandbox.
+The fixture deliberately places that probe at the Profile's Python entrypoint;
+it is not CPython and is not a product Execution API. These tests establish
+the checked kernel properties, not a complete security claim for arbitrary
+Workloads. See the [T04 learning guide](learning/t04-sandbox-creation.md).

--- a/docs/testing/t04-acceptance.md
+++ b/docs/testing/t04-acceptance.md
@@ -1,0 +1,71 @@
+# T04 acceptance record — 2026-09-05
+
+Scope: [issue #10](https://github.com/TH1NKING/Build-your-own-Docker-with-Go/issues/10).
+Implementation baseline: `63a38451ba43d81e203b02daadbd11db5c40bc5b`.
+
+## Executed verification
+
+- Native Linux Go `1.26.1 linux/amd64` on
+  `5.15.153.1-microsoft-standard-WSL2`.
+- Repository source was copied into a disposable mount/PID/network namespace.
+  Formatting checks, `go vet ./...`, `go test ./...`, `go build ./...`, and
+  Shell syntax checks passed. Ordinary tests ran as UID/GID 1000 with cleared
+  supplementary groups, including the real Unix socket protocol suite.
+- `bash tests/run-sandbox-creation-linux.sh` passed all nine top-level creation
+  tests as root in a separate namespace with a private temporary filesystem.
+  These cover exact UID/GID mappings, cleared host groups, root replacement,
+  read-only/private mounts, absent host filesystem handles, an in-Sandbox
+  marker/write probe, concurrent disjoint IDs, invalid configuration, invalid
+  Profile ownership/symlinks, preservation of existing directories, kernel
+  mapping rejection and launcher-inherited directory handles.
+- Windows `go test ./...` and `go vet ./...` passed for the platform-applicable
+  packages. Windows results are not evidence of kernel isolation.
+
+The checked-in GitHub Actions job runs the same creation script on Ubuntu.
+This record reports local execution; a hosted CI run has not been dispatched.
+The production CPython content/reproducibility suite was not rerun for T04;
+the creation tests install real test Bundles with a clearly identified trusted
+conformance executable, not CPython.
+
+## Observed red-to-green cases
+
+1. Creation initially failed because the Supervisor had no subordinate-ID
+   configuration or implementation. The mapped, live Sandbox test now passes.
+2. The filesystem-boundary test found Go runtime cgroup descriptors surviving
+   root replacement. Bootstrap runtime settings now prevent their retention.
+3. A Profile directory transferred to an untrusted owner was initially
+   accepted. Handle-based ownership/mode checks now reject it.
+4. Review identified a shell-inherited host directory FD. A real launcher
+   reproduced the leak at FD 9; startup close-on-exec marking fixes the test.
+
+An initial bind-mount attempt using inherited parent directory FDs failed with
+`EINVAL`. The final implementation inherits an independently scoped cwd,
+which the kernel translates into the new mount namespace. The learning guide
+explains this distinction and the associated tradeoffs.
+
+## Standards
+
+Initial review found one P1 violation of ADR-0017: `ExtraFiles` did not exclude
+non-CLOEXEC descriptors inherited from the Supervisor's launcher. The change
+now seals inherited descriptors before serving, preserves runtime handles,
+and explicitly passes only required handles across exec. The regression test
+and follow-up review confirmed the fix. No unresolved standards violations or
+actionable smell-baseline findings remain.
+
+## Spec
+
+No unresolved findings. The implementation and kernel tests cover all three
+T04 criteria: configured nonzero host identity mapping, a read-only Profile
+root installed through `pivot_root` with old-root detachment, and an actual
+in-namespace probe that cannot reach a host-only marker.
+
+Final review counts: Standards 0 unresolved (one P1 fixed); Spec 0 unresolved.
+
+## Remaining boundary
+
+This is creation acceptance, not full Sandbox security acceptance. Product
+Execution, a production Sandbox Init, complete failure recovery, capabilities,
+System Call Policy, controlled mounts/Workspace and Resource Budgets remain
+the responsibility of subsequent tickets. The trusted bootstrap is idle.
+See [the T04 learning guide](../learning/t04-sandbox-creation.md) for the
+implementation explanation and reproducible commands.

--- a/internal/sandboxsupervisor/bootstrap_linux.go
+++ b/internal/sandboxsupervisor/bootstrap_linux.go
@@ -1,0 +1,98 @@
+//go:build linux
+
+package sandboxsupervisor
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"syscall"
+)
+
+// RunBootstrap is the private re-exec entry point of sandboxd. It accepts no
+// paths or commands: the Supervisor supplies only already-open handles. T04
+// keeps this trusted PID 1 alive; Workload execution is implemented by T05.
+func RunBootstrap() error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	if os.Getpid() != 1 || os.Geteuid() != 0 {
+		return errors.New("Sandbox bootstrap requires namespace PID 1 and internal UID zero")
+	}
+	ready := os.NewFile(3, "bootstrap-ready")
+	lifetime := os.NewFile(4, "bootstrap-lifetime")
+	profile := os.NewFile(5, "profile-root")
+	defer ready.Close()
+	defer lifetime.Close()
+	defer profile.Close()
+	for _, file := range []*os.File{ready, lifetime} {
+		info, err := file.Stat()
+		if err != nil || info.Mode()&os.ModeNamedPipe == 0 {
+			return errors.New("Sandbox bootstrap requires private inherited pipes")
+		}
+	}
+	if err := syscall.Mount("", "/", "", syscall.MS_REC|syscall.MS_PRIVATE, ""); err != nil {
+		return fmt.Errorf("make Sandbox mount propagation private: %w", err)
+	}
+	cwd, err := os.Stat(".")
+	if err != nil {
+		return err
+	}
+	selected, err := profile.Stat()
+	if err != nil || !os.SameFile(cwd, selected) {
+		return errors.New("bootstrap cwd is not the selected Profile")
+	}
+	// Build the mountpoint in this namespace. No host directory is made
+	// writable or traversable by subordinate IDs, including 0700 ancestors.
+	temporary, err := os.Lstat("/tmp")
+	if err != nil || !temporary.IsDir() || temporary.Mode()&os.ModeSymlink != 0 {
+		return errors.New("bootstrap requires a real /tmp directory")
+	}
+	if err := syscall.Mount("tmpfs", "/tmp", "tmpfs", syscall.MS_NOSUID|syscall.MS_NODEV, "size=1m,nr_inodes=16,mode=0700"); err != nil {
+		return fmt.Errorf("mount private bootstrap staging: %w", err)
+	}
+	const newRoot = "/tmp/rootfs"
+	if err := os.Mkdir(newRoot, 0o755); err != nil {
+		return err
+	}
+	// Non-recursive bind excludes nested host mounts. Cwd was translated by
+	// CLONE_NEWNS; the inherited Profile FD still refers to the parent mount.
+	if err := syscall.Mount(".", newRoot, "", syscall.MS_BIND, ""); err != nil {
+		return fmt.Errorf("bind Profile root filesystem: %w", err)
+	}
+	var filesystem syscall.Statfs_t
+	if err := syscall.Statfs(newRoot, &filesystem); err != nil {
+		return fmt.Errorf("inspect Profile mount flags: %w", err)
+	}
+	const preserved = syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOEXEC | syscall.MS_NOATIME | syscall.MS_NODIRATIME | syscall.MS_RELATIME | syscall.MS_SYNCHRONOUS | syscall.MS_MANDLOCK
+	flags := uintptr(filesystem.Flags)&preserved | syscall.MS_BIND | syscall.MS_REMOUNT | syscall.MS_RDONLY | syscall.MS_NOSUID | syscall.MS_NODEV
+	if err := syscall.Mount("", newRoot, "", flags, ""); err != nil {
+		return fmt.Errorf("make Profile mount read-only: %w", err)
+	}
+	if err := syscall.Chdir(newRoot); err != nil {
+		return fmt.Errorf("enter Profile mount: %w", err)
+	}
+	// Stack the old root on the new one, then detach it. This is the documented
+	// pivot_root(".", ".") idiom; it needs no writable put_old directory.
+	if err := syscall.PivotRoot(".", "."); err != nil {
+		return fmt.Errorf("pivot Sandbox root: %w", err)
+	}
+	if err := syscall.Unmount(".", syscall.MNT_DETACH); err != nil {
+		return fmt.Errorf("detach old Sandbox root: %w", err)
+	}
+	if err := syscall.Chdir("/"); err != nil {
+		return fmt.Errorf("reset Sandbox working directory: %w", err)
+	}
+	if err := profile.Close(); err != nil {
+		return err
+	}
+	if _, err := ready.Write([]byte{'R'}); err != nil {
+		return err
+	}
+	ready.Close()
+	// EOF also ends this trusted bootstrap if the Supervisor dies. No caller
+	// command or Workload can enter through this lifetime-only channel.
+	_, err = io.Copy(io.Discard, lifetime)
+	return err
+}

--- a/internal/sandboxsupervisor/creation_linux.go
+++ b/internal/sandboxsupervisor/creation_linux.go
@@ -1,0 +1,263 @@
+//go:build linux
+
+package sandboxsupervisor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const sandboxIdentityCount = 65536
+
+// ExtraFiles is not an inheritance whitelist: Go preserves a launcher's
+// descriptors that lack CLOEXEC. Seal them once before serving. Marking instead
+// of closing also keeps the Supervisor's own runtime descriptors valid. exec
+// will explicitly clear CLOEXEC on the selected private pipes/Profile handles.
+func sealInheritedDescriptors() error {
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		return fmt.Errorf("inspect inherited Supervisor descriptors: %w", err)
+	}
+	for _, entry := range entries {
+		fd, err := strconv.Atoi(entry.Name())
+		if err != nil || fd < 3 {
+			continue
+		}
+		_, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), syscall.F_SETFD, syscall.FD_CLOEXEC)
+		if errno != 0 && errno != syscall.EBADF {
+			return fmt.Errorf("seal inherited Supervisor descriptor: %w", errno)
+		}
+	}
+	return nil
+}
+
+func validateSubordinateIDs(config ServerConfig) error {
+	if config.SubUIDStart == 0 && config.SubGIDStart == 0 && config.SubIDCount == 0 {
+		return nil // Preserve the unprivileged protocol-only mode.
+	}
+	if os.Geteuid() != 0 {
+		return errors.New("Sandbox creation requires a root Supervisor")
+	}
+	if config.SubUIDStart == 0 || config.SubGIDStart == 0 || config.SubIDCount == 0 || config.SubIDCount%sandboxIdentityCount != 0 {
+		return errors.New("subordinate UID/GID starts must be nonzero and count must be a positive multiple of 65536")
+	}
+	// UID/GID -1 is reserved by the kernel. Check without overflowing uint.
+	const maximumID = uint64(1<<32 - 2)
+	for _, start := range []uint{config.SubUIDStart, config.SubGIDStart} {
+		if uint64(start) > maximumID || uint64(config.SubIDCount)-1 > maximumID-uint64(start) {
+			return errors.New("subordinate ID range exceeds Linux UID/GID bounds")
+		}
+	}
+	return nil
+}
+
+// Open each directory without following links. Handles keep trusted roots
+// separate from caller identifiers throughout privileged path resolution.
+func openProfileRootFilesystem(store *os.Root, digest string) (*os.File, error) {
+	const flags = os.O_RDONLY | syscall.O_DIRECTORY | syscall.O_NOFOLLOW | syscall.O_CLOEXEC
+	shard, err := store.OpenFile("sha256", flags, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer shard.Close()
+	if err := validateInstalledDirectory(shard, 0o755); err != nil {
+		return nil, err
+	}
+	profileFD, err := syscall.Openat(int(shard.Fd()), digest, flags, 0)
+	if err != nil {
+		return nil, err
+	}
+	profile := os.NewFile(uintptr(profileFD), "installed-profile")
+	defer profile.Close()
+	if err := validateInstalledDirectory(profile, 0o555); err != nil {
+		return nil, err
+	}
+	rootFD, err := syscall.Openat(profileFD, "rootfs", flags, 0)
+	if err != nil {
+		return nil, err
+	}
+	rootfs := os.NewFile(uintptr(rootFD), "profile-rootfs")
+	if err := validateInstalledDirectory(rootfs, 0o555); err != nil {
+		rootfs.Close()
+		return nil, err
+	}
+	return rootfs, nil
+}
+
+func validateInstalledDirectory(directory *os.File, mode fs.FileMode) error {
+	info, err := directory.Stat()
+	if err != nil {
+		return err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat.Uid != 0 || !info.IsDir() || info.Mode().Perm() != mode {
+		return fmt.Errorf("installed Profile directory must be root-owned with mode %04o", mode)
+	}
+	return nil
+}
+
+type sandboxCreator struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	config ServerConfig
+	root   *os.Root
+	mu     sync.Mutex
+	active map[string]*createdSandbox
+	wait   sync.WaitGroup
+}
+
+type createdSandbox struct {
+	identityOffset uint
+}
+
+func newSandboxCreator(ctx context.Context, config ServerConfig, root *os.Root) *sandboxCreator {
+	ctx, cancel := context.WithCancel(ctx)
+	return &sandboxCreator{ctx: ctx, cancel: cancel, config: config, root: root, active: make(map[string]*createdSandbox)}
+}
+
+func (creator *sandboxCreator) enabled() bool { return creator.config.SubIDCount != 0 }
+
+func (creator *sandboxCreator) close() {
+	creator.cancel()
+	creator.wait.Wait()
+}
+
+func (creator *sandboxCreator) reserve(id string) (*createdSandbox, ErrorCode) {
+	creator.mu.Lock()
+	defer creator.mu.Unlock()
+	if creator.ctx.Err() != nil {
+		return nil, ErrorCodeCreationFailed
+	}
+	if _, exists := creator.active[id]; exists {
+		return nil, ErrorCodeSandboxExists
+	}
+	used := make(map[uint]bool, len(creator.active))
+	for _, sandbox := range creator.active {
+		used[sandbox.identityOffset] = true
+	}
+	var offset uint
+	for offset < creator.config.SubIDCount && used[offset] {
+		offset += sandboxIdentityCount
+	}
+	if offset == creator.config.SubIDCount {
+		return nil, ErrorCodeIdentityRangeExhausted
+	}
+	if err := creator.root.Mkdir(id, 0o755); err != nil {
+		if errors.Is(err, fs.ErrExist) {
+			return nil, ErrorCodeSandboxExists
+		}
+		return nil, ErrorCodeCreationFailed
+	}
+	sandbox := &createdSandbox{identityOffset: offset}
+	creator.active[id] = sandbox
+	return sandbox, ""
+}
+
+func (creator *sandboxCreator) release(id string) {
+	creator.mu.Lock()
+	defer creator.mu.Unlock()
+	// Only remove the empty directory this creation owns. Never recurse
+	// into an unexpected tree or remove a pre-existing Sandbox identifier.
+	_ = creator.root.Remove(id)
+	delete(creator.active, id)
+}
+
+func (creator *sandboxCreator) create(id string, profile *os.File) ErrorCode {
+	sandbox, code := creator.reserve(id)
+	if code != "" {
+		return code
+	}
+	transferred := false
+	defer func() {
+		if !transferred {
+			creator.release(id)
+		}
+	}()
+	readyReader, readyWriter, err := os.Pipe()
+	if err != nil {
+		return ErrorCodeCreationFailed
+	}
+	defer readyReader.Close()
+	defer readyWriter.Close()
+	lifeReader, lifeWriter, err := os.Pipe()
+	if err != nil {
+		return ErrorCodeCreationFailed
+	}
+	defer lifeReader.Close()
+	defer func() {
+		if !transferred {
+			lifeWriter.Close()
+		}
+	}()
+
+	// Namespace construction happens before exec, so no goroutine in the
+	// network-facing Supervisor ever changes its own namespaces or root.
+	command := exec.CommandContext(creator.ctx, "/proc/self/exe", "--sandbox-bootstrap")
+	// Go's container-aware GOMAXPROCS otherwise keeps host cgroup files open
+	// across pivot_root. These trusted bootstrap settings close those handles
+	// at runtime startup, before readiness. This is not a Workload CPU budget.
+	command.Env = []string{"GOMAXPROCS=1", "GODEBUG=containermaxprocs=0,updatemaxprocs=0"}
+	command.ExtraFiles = []*os.File{readyWriter, lifeReader, profile}
+	// Force an exec-managed pipe even when the Supervisor logs to a host file.
+	command.Stderr = struct{ io.Writer }{os.Stderr}
+	command.SysProcAttr = &syscall.SysProcAttr{
+		Cloneflags:                 syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS | syscall.CLONE_NEWPID | syscall.CLONE_NEWNET,
+		UidMappings:                []syscall.SysProcIDMap{{ContainerID: 0, HostID: int(creator.config.SubUIDStart + sandbox.identityOffset), Size: sandboxIdentityCount}},
+		GidMappings:                []syscall.SysProcIDMap{{ContainerID: 0, HostID: int(creator.config.SubGIDStart + sandbox.identityOffset), Size: sandboxIdentityCount}},
+		GidMappingsEnableSetgroups: true,
+		Credential:                 &syscall.Credential{Uid: 0, Gid: 0, Groups: []uint32{}},
+	}
+	if err := startFromProfile(command, profile); err != nil {
+		fmt.Fprintln(os.Stderr, "Sandbox creation:", err)
+		return ErrorCodeCreationFailed
+	}
+	readyWriter.Close()
+	lifeReader.Close()
+	_ = readyReader.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var ready [1]byte
+	if _, err := io.ReadFull(readyReader, ready[:]); err != nil || ready[0] != 'R' {
+		_ = command.Process.Kill()
+		_ = command.Wait()
+		return ErrorCodeCreationFailed
+	}
+	transferred = true
+	creator.wait.Add(1)
+	go func() {
+		defer creator.wait.Done()
+		defer lifeWriter.Close()
+		_ = command.Wait()
+		creator.release(id)
+	}()
+	return ""
+}
+
+func startFromProfile(command *exec.Cmd, profile *os.File) error {
+	started := make(chan error, 1)
+	go func() {
+		runtime.LockOSThread()
+		// Do not unlock: Go retires this OS thread on return. CLONE_FS gives
+		// only this thread its own cwd; other Supervisor threads keep theirs.
+		if err := syscall.Unshare(syscall.CLONE_FS); err != nil {
+			started <- err
+			return
+		}
+		if err := syscall.Fchdir(int(profile.Fd())); err != nil {
+			started <- err
+			return
+		}
+		// Leave command.Dir empty. CLONE_NEWNS translates inherited cwd into
+		// the new mount namespace, unlike an inherited directory FD.
+		started <- command.Start()
+	}()
+	return <-started
+}

--- a/internal/sandboxsupervisor/protocol.go
+++ b/internal/sandboxsupervisor/protocol.go
@@ -12,13 +12,16 @@ const (
 type ErrorCode string
 
 const (
-	ErrorCodeProfileNotFound      ErrorCode = "profile_not_found"
-	ErrorCodeUnsupportedVersion   ErrorCode = "unsupported_version"
-	ErrorCodeUnknownOperation     ErrorCode = "unknown_operation"
-	ErrorCodeMalformedRequest     ErrorCode = "malformed_request"
-	ErrorCodeInvalidReference     ErrorCode = "invalid_reference"
-	ErrorCodeRequestTooLarge      ErrorCode = "request_too_large"
-	ErrorCodeOperationUnavailable ErrorCode = "operation_unavailable"
+	ErrorCodeProfileNotFound        ErrorCode = "profile_not_found"
+	ErrorCodeUnsupportedVersion     ErrorCode = "unsupported_version"
+	ErrorCodeUnknownOperation       ErrorCode = "unknown_operation"
+	ErrorCodeMalformedRequest       ErrorCode = "malformed_request"
+	ErrorCodeInvalidReference       ErrorCode = "invalid_reference"
+	ErrorCodeRequestTooLarge        ErrorCode = "request_too_large"
+	ErrorCodeOperationUnavailable   ErrorCode = "operation_unavailable"
+	ErrorCodeCreationFailed         ErrorCode = "creation_failed"
+	ErrorCodeSandboxExists          ErrorCode = "sandbox_exists"
+	ErrorCodeIdentityRangeExhausted ErrorCode = "identity_range_exhausted"
 )
 
 type CreateSandboxRequest struct {
@@ -34,7 +37,9 @@ type CreateSandboxResponse struct {
 	Error     *ProtocolError
 }
 
-type CreateSandboxResult struct{}
+type CreateSandboxResult struct {
+	SandboxID string `json:"sandbox_id"`
+}
 
 type ProtocolError struct {
 	Code ErrorCode `json:"code"`

--- a/internal/sandboxsupervisor/server_linux.go
+++ b/internal/sandboxsupervisor/server_linux.go
@@ -19,6 +19,9 @@ type ServerConfig struct {
 	SocketPath   string
 	ProfileStore string
 	SandboxRoot  string
+	SubUIDStart  uint
+	SubGIDStart  uint
+	SubIDCount   uint
 }
 
 type requestEnvelope struct {
@@ -42,11 +45,18 @@ type responseEnvelope struct {
 
 type server struct {
 	profileStore *os.Root
+	creator      *sandboxCreator
 }
 
 const maximumConcurrentControlConnections = 16
 
 func Serve(ctx context.Context, config ServerConfig) error {
+	if err := sealInheritedDescriptors(); err != nil {
+		return err
+	}
+	if err := validateSubordinateIDs(config); err != nil {
+		return err
+	}
 	if err := validateTrustedPaths(config); err != nil {
 		return err
 	}
@@ -60,6 +70,8 @@ func Serve(ctx context.Context, config ServerConfig) error {
 		return err
 	}
 	defer sandboxRoot.Close()
+	creator := newSandboxCreator(ctx, config, sandboxRoot)
+	defer creator.close()
 
 	listener, err := net.ListenUnix("unix", &net.UnixAddr{Name: config.SocketPath, Net: "unix"})
 	if err != nil {
@@ -81,7 +93,7 @@ func Serve(ctx context.Context, config ServerConfig) error {
 		}
 	}()
 
-	service := &server{profileStore: profileStore}
+	service := &server{profileStore: profileStore, creator: creator}
 	connectionSlots := make(chan struct{}, maximumConcurrentControlConnections)
 	var handlers sync.WaitGroup
 	defer handlers.Wait()
@@ -170,7 +182,22 @@ func (service *server) createSandboxResponse(requestID string, rawParameters jso
 	}
 	_ = profile.Close()
 
-	return protocolErrorResponse(requestID, ErrorCodeOperationUnavailable)
+	if !service.creator.enabled() {
+		return protocolErrorResponse(requestID, ErrorCodeOperationUnavailable)
+	}
+	rootfs, err := openProfileRootFilesystem(service.profileStore, digest)
+	if err != nil {
+		return protocolErrorResponse(requestID, ErrorCodeInvalidReference)
+	}
+	defer rootfs.Close()
+	if code := service.creator.create(parameters.SandboxID, rootfs); code != "" {
+		return protocolErrorResponse(requestID, code)
+	}
+	return responseEnvelope{
+		Schema:    ResponseSchemaV1,
+		RequestID: requestID,
+		Result:    &CreateSandboxResult{SandboxID: parameters.SandboxID},
+	}
 }
 
 func (service *server) writeResponse(connection *net.UnixConn, response responseEnvelope) {

--- a/tests/run-sandbox-creation-linux.sh
+++ b/tests/run-sandbox-creation-linux.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run only on a Linux test machine. All test mounts, processes, networking and
+# temporary files live in a disposable namespace, including a private /tmp.
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ -z "${SANDBOX_TEST_BIN_DIR:-}" ]]; then
+  sandbox_bin_dir="$repository_root/.cache/sandbox-creation"
+  mkdir -p -- "$sandbox_bin_dir"
+  cd -- "$repository_root"
+  export CGO_ENABLED=0
+  go build -o "$sandbox_bin_dir/sandboxd" ./cmd/sandboxd
+  go build -o "$sandbox_bin_dir/profile-bundle" ./cmd/profile-bundle
+  go build -o "$sandbox_bin_dir/sandbox-root-probe" ./tests/testdata/sandbox-root-probe
+  go test -c -tags='sandbox_root,profilebundle_root' \
+    -o "$sandbox_bin_dir/sandbox-creation-tests" ./tests
+else
+  sandbox_bin_dir="$(cd -- "$SANDBOX_TEST_BIN_DIR" && pwd)"
+fi
+
+for binary in sandboxd profile-bundle sandbox-root-probe sandbox-creation-tests; do
+  [[ -x "$sandbox_bin_dir/$binary" ]] || { echo "Missing executable: $sandbox_bin_dir/$binary" >&2; exit 1; }
+done
+
+privilege=()
+if [[ "$EUID" != 0 ]]; then
+  privilege=(sudo -n)
+fi
+
+exec "${privilege[@]}" unshare --mount --pid --fork --mount-proc --net --propagation private \
+  bash -c '
+    set -euo pipefail
+    cd -- "$1"
+    mount -t tmpfs -o size=512m,mode=1777,nosuid,nodev tmpfs /tmp
+    # Inherited cwd keeps the binaries reachable even when the checkout or
+    # supplied bin directory is under the now-covered host /tmp.
+    mkdir /tmp/t04-bin
+    cp -- ./sandboxd ./profile-bundle ./sandbox-root-probe ./sandbox-creation-tests /tmp/t04-bin/
+    cd /
+    export SANDBOXD_CLI=/tmp/t04-bin/sandboxd
+    export PROFILE_BUNDLE_CLI=/tmp/t04-bin/profile-bundle
+    export SANDBOX_ROOT_PROBE=/tmp/t04-bin/sandbox-root-probe
+    uname -sr
+    exec /tmp/t04-bin/sandbox-creation-tests -test.v -test.run="^TestSandboxCreation" -test.timeout=120s
+  ' sandbox-creation "$sandbox_bin_dir"

--- a/tests/sandbox_creation_linux_test.go
+++ b/tests/sandbox_creation_linux_test.go
@@ -1,0 +1,343 @@
+//go:build linux && sandbox_root && profilebundle_root
+
+package workspace_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// This suite drives the published Supervisor protocol. /proc observations are
+// host security invariants, not a dependency on Supervisor implementation APIs.
+func TestSandboxCreationMapsOnlyConfiguredSubordinateIDs(t *testing.T) {
+	fixture, identity := installedSandboxCreationFixture(t)
+	t.Cleanup(startSandboxSupervisor(t, fixture,
+		"--subuid-start", "200000", "--subgid-start", "300000", "--subid-count", "131072"))
+	response := exchangeSandboxSupervisorMessage(t, fixture.socketPath,
+		createSandboxWireRequest(t, "req-create", "run-first", identity))
+	assertSandboxCreated(t, response, "run-first")
+	pid := sandboxProcessForRoot(t, fixture, identity)
+	for name, want := range map[string]string{
+		"uid_map": "0 200000 65536",
+		"gid_map": "0 300000 65536",
+	} {
+		contents, err := os.ReadFile(filepath.Join("/proc", pid, name))
+		if err != nil || strings.Join(strings.Fields(string(contents)), " ") != want {
+			t.Fatalf("%s = %q, err=%v; want %s", name, contents, err, want)
+		}
+	}
+	status, err := os.ReadFile(filepath.Join("/proc", pid, "status"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(string(status), "\n") {
+		if strings.HasPrefix(line, "Groups:") && strings.TrimSpace(strings.TrimPrefix(line, "Groups:")) != "" {
+			t.Fatalf("Sandbox retained supplementary host groups: %s", line)
+		}
+	}
+}
+
+func TestSandboxCreationDetachesHostRootAndKeepsProfileReadOnly(t *testing.T) {
+	fixture, identity := installedSandboxCreationFixture(t)
+	marker := filepath.Join(filepath.Dir(fixture.sandboxRoot), "host-only-marker")
+	if err := os.WriteFile(marker, []byte("host secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A world-traversable ancestor makes denial independent of host DAC.
+	if err := os.Chmod(filepath.Dir(fixture.sandboxRoot), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(startSandboxSupervisor(t, fixture,
+		"--subuid-start", "200000", "--subgid-start", "300000", "--subid-count", "65536"))
+	response := exchangeSandboxSupervisorMessage(t, fixture.socketPath,
+		createSandboxWireRequest(t, "req-root", "run-root", identity))
+	assertSandboxCreated(t, response, "run-root")
+	pid := sandboxProcessForRoot(t, fixture, identity)
+
+	for _, name := range []string{"user", "mnt", "pid", "net"} {
+		sandbox, err := os.Stat(filepath.Join("/proc", pid, "ns", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		host, err := os.Stat(filepath.Join("/proc/self/ns", name))
+		if err != nil || os.SameFile(sandbox, host) {
+			t.Fatalf("Sandbox shares host %s namespace: %v", name, err)
+		}
+	}
+	mountinfo, err := os.ReadFile(filepath.Join("/proc", pid, "mountinfo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(mountinfo)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("old-root mounts remain visible:\n%s", mountinfo)
+	}
+	fields := strings.Fields(lines[0])
+	if len(fields) < 10 || fields[4] != "/" || !strings.Contains(","+fields[5]+",", ",ro,") || strings.Contains(lines[0], "shared:") || strings.Contains(lines[0], "master:") {
+		t.Fatalf("root mount is not a distinct read-only private mount:\n%s", mountinfo)
+	}
+	fdDirectory := filepath.Join("/proc", pid, "fd")
+	fds, err := os.ReadDir(fdDirectory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, fd := range fds {
+		target, err := os.Readlink(filepath.Join(fdDirectory, fd.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.HasPrefix(target, "anon_inode:") {
+			continue
+		}
+		info, err := os.Stat(filepath.Join(fdDirectory, fd.Name()))
+		if err == nil && (info.IsDir() || info.Mode().IsRegular()) {
+			t.Fatalf("Sandbox retains host filesystem descriptor %s (%s): %v", fd.Name(), target, info.Mode())
+		}
+	}
+	command := exec.Command("nsenter", "--target", pid, "--user", "--mount", "--pid", "--net", "--root", "--wd=/",
+		"--", "/opt/python/bin/python3", marker)
+	if output, err := command.CombinedOutput(); err != nil || string(output) != "host-root-unreachable; profile-read-only\n" {
+		t.Fatalf("kernel Workload probe failed: %v\n%s", err, output)
+	}
+	// Parent mount namespace and selected Profile contents remain intact.
+	if content, err := os.ReadFile(marker); err != nil || string(content) != "host secret" {
+		t.Fatalf("host marker changed: %q, %v", content, err)
+	}
+	var hostFilesystem syscall.Statfs_t
+	if err := syscall.Statfs(filepath.Dir(marker), &hostFilesystem); err != nil || hostFilesystem.Flags&syscall.MS_RDONLY != 0 {
+		t.Fatalf("Sandbox read-only remount propagated to the host: %v", err)
+	}
+}
+
+func assertSandboxCreated(t *testing.T, response []byte, id string) {
+	t.Helper()
+	var envelope struct {
+		Result *struct {
+			SandboxID string `json:"sandbox_id"`
+		} `json:"result"`
+		Error any `json:"error"`
+	}
+	if err := json.Unmarshal(response, &envelope); err != nil || envelope.Result == nil || envelope.Result.SandboxID != id || envelope.Error != nil {
+		t.Fatalf("create returned %s, want confirmed Sandbox %s (decode: %v)", response, id, err)
+	}
+}
+
+func TestSandboxCreationRejectsProfileOutsideInstallerOwnership(t *testing.T) {
+	fixture, identity := installedSandboxCreationFixture(t)
+	profileDirectory := filepath.Join(fixture.profileStore, "sha256", strings.TrimPrefix(identity, "sha256:"))
+	// An unprivileged owner could replace rootfs after selection. Valid rootfs
+	// permissions alone cannot make the containing Profile trustworthy.
+	if err := os.Chown(profileDirectory, 12345, 12345); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(startSandboxSupervisor(t, fixture,
+		"--subuid-start", "200000", "--subgid-start", "300000", "--subid-count", "65536"))
+	response := exchangeSandboxSupervisorMessage(t, fixture.socketPath,
+		createSandboxWireRequest(t, "req-untrusted-profile", "run-untrusted", identity))
+	assertSandboxSupervisorErrorCode(t, response, "invalid_reference")
+}
+
+func TestSandboxCreationAllocatesDistinctIdentitiesConcurrently(t *testing.T) {
+	fixture, identity := installedSandboxCreationFixture(t)
+	t.Cleanup(startSandboxSupervisor(t, fixture,
+		"--subuid-start", "200000", "--subgid-start", "300000", "--subid-count", "131072"))
+	var clients sync.WaitGroup
+	for _, id := range []string{"run-one", "run-two"} {
+		clients.Go(func() {
+			response := exchangeSandboxSupervisorMessage(t, fixture.socketPath, createSandboxWireRequest(t, "req-"+id, id, identity))
+			assertSandboxCreated(t, response, id)
+		})
+	}
+	clients.Wait()
+	pids := sandboxProcessesForRoot(t, fixture, identity)
+	if len(pids) != 2 {
+		t.Fatalf("active Sandbox count = %d, want 2", len(pids))
+	}
+	var mappings []string
+	for _, pid := range pids {
+		contents, err := os.ReadFile(filepath.Join("/proc", pid, "uid_map"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		mappings = append(mappings, strings.Join(strings.Fields(string(contents)), " "))
+	}
+	sort.Strings(mappings)
+	if strings.Join(mappings, ";") != "0 200000 65536;0 265536 65536" {
+		t.Fatalf("concurrent Sandbox UID maps overlap or leave configured range: %v", mappings)
+	}
+	response := exchangeSandboxSupervisorMessage(t, fixture.socketPath, createSandboxWireRequest(t, "req-full", "run-three", identity))
+	assertSandboxSupervisorErrorCode(t, response, "identity_range_exhausted")
+	response = exchangeSandboxSupervisorMessage(t, fixture.socketPath, createSandboxWireRequest(t, "req-duplicate", "run-one", identity))
+	assertSandboxSupervisorErrorCode(t, response, "sandbox_exists")
+	if pids := sandboxProcessesForRoot(t, fixture, identity); len(pids) != 2 {
+		t.Fatalf("rejected creation disturbed existing Sandboxes: %v", pids)
+	}
+}
+
+func TestSandboxCreationRejectsUnsafeSubordinateConfiguration(t *testing.T) {
+	fixture := newSafeSandboxSupervisorFixture(t)
+	for _, arguments := range [][]string{
+		{"--subuid-start", "0", "--subgid-start", "300000", "--subid-count", "65536"},
+		{"--subuid-start", "200000", "--subgid-start", "0", "--subid-count", "65536"},
+		{"--subuid-start", "200000", "--subgid-start", "300000"},
+		{"--subuid-start", "200000", "--subgid-start", "300000", "--subid-count", "1000"},
+		{"--subuid-start", "4294960000", "--subgid-start", "300000", "--subid-count", "65536"},
+		{"--subuid-start", "200000", "--subgid-start", "4294960000", "--subid-count", "65536"},
+	} {
+		t.Run(strings.Join(arguments, "_"), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			command := exec.CommandContext(ctx, sandboxdCommandPath(t), "--socket", fixture.socketPath, "--profile-store", fixture.profileStore, "--sandbox-root", fixture.sandboxRoot)
+			command.Args = append(command.Args, arguments...)
+			if output, err := command.CombinedOutput(); err == nil || ctx.Err() != nil {
+				t.Fatalf("unsafe subordinate mapping accepted: %v\n%s", arguments, output)
+			}
+			if _, err := os.Lstat(fixture.socketPath); !os.IsNotExist(err) {
+				t.Fatalf("invalid mapping published socket: %v", err)
+			}
+		})
+	}
+}
+
+func TestSandboxCreationPreservesPreexistingSandboxDirectory(t *testing.T) {
+	fixture, identity := installedSandboxCreationFixture(t)
+	existing := filepath.Join(fixture.sandboxRoot, "run-existing")
+	if err := os.Mkdir(existing, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(existing, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("preserve"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(startSandboxSupervisor(t, fixture,
+		"--subuid-start", "200000", "--subgid-start", "300000", "--subid-count", "65536"))
+	response := exchangeSandboxSupervisorMessage(t, fixture.socketPath, createSandboxWireRequest(t, "req-existing", "run-existing", identity))
+	assertSandboxSupervisorErrorCode(t, response, "sandbox_exists")
+	if contents, err := os.ReadFile(sentinel); err != nil || string(contents) != "preserve" {
+		t.Fatalf("pre-existing state modified: %q, %v", contents, err)
+	}
+	response = exchangeSandboxSupervisorMessage(t, fixture.socketPath, createSandboxWireRequest(t, "req-after-conflict", "run-new", identity))
+	assertSandboxCreated(t, response, "run-new")
+}
+
+func TestSandboxCreationRejectsRootFilesystemSymlink(t *testing.T) {
+	fixture, identity := installedSandboxCreationFixture(t)
+	profile := filepath.Join(fixture.profileStore, "sha256", strings.TrimPrefix(identity, "sha256:"))
+	rootfs := filepath.Join(profile, "rootfs")
+	if err := os.Rename(rootfs, rootfs+"-original"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("rootfs-original", rootfs); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(startSandboxSupervisor(t, fixture,
+		"--subuid-start", "200000", "--subgid-start", "300000", "--subid-count", "65536"))
+	response := exchangeSandboxSupervisorMessage(t, fixture.socketPath, createSandboxWireRequest(t, "req-link", "run-link", identity))
+	assertSandboxSupervisorErrorCode(t, response, "invalid_reference")
+}
+
+func TestSandboxCreationFailsClosedWhenKernelRejectsIdentityMapping(t *testing.T) {
+	fixture, identity := installedSandboxCreationFixture(t)
+	// An outer User Namespace containing only ID zero cannot grant the child
+	// the requested subordinate range. The real kernel rejects map creation;
+	// no fault-injection hook is added to the Supervisor.
+	fixture.launchPrefix = []string{"unshare", "--user", "--map-root-user"}
+	t.Cleanup(startSandboxSupervisor(t, fixture,
+		"--subuid-start", "200000", "--subgid-start", "300000", "--subid-count", "65536"))
+	for _, requestID := range []string{"req-denied", "req-retry-denied"} {
+		response := exchangeSandboxSupervisorMessage(t, fixture.socketPath, createSandboxWireRequest(t, requestID, "run-denied", identity))
+		assertSandboxSupervisorErrorCode(t, response, "creation_failed")
+		if entries, err := os.ReadDir(fixture.sandboxRoot); err != nil || len(entries) != 0 {
+			t.Fatalf("failed creation retained runtime state: %v, %v", entries, err)
+		}
+		if strings.Contains(string(response), fixture.profileStore) {
+			t.Fatalf("failure disclosed host path: %s", response)
+		}
+	}
+}
+
+func TestSandboxCreationDoesNotInheritLauncherHostDirectory(t *testing.T) {
+	fixture, identity := installedSandboxCreationFixture(t)
+	fixture.launchPrefix = []string{"bash", "-c", `exec 9<"$1"; exec "${@:2}"`, "sandboxd-inherited-fd", filepath.Dir(fixture.sandboxRoot)}
+	t.Cleanup(startSandboxSupervisor(t, fixture,
+		"--subuid-start", "200000", "--subgid-start", "300000", "--subid-count", "65536"))
+	response := exchangeSandboxSupervisorMessage(t, fixture.socketPath, createSandboxWireRequest(t, "req-inherited-fd", "run-inherited-fd", identity))
+	assertSandboxCreated(t, response, "run-inherited-fd")
+	pid := sandboxProcessForRoot(t, fixture, identity)
+	entries, err := os.ReadDir(filepath.Join("/proc", pid, "fd"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		info, err := os.Stat(filepath.Join("/proc", pid, "fd", entry.Name()))
+		if err == nil && info.IsDir() {
+			t.Fatalf("Sandbox retained launcher host directory at FD %s", entry.Name())
+		}
+	}
+}
+
+func installedSandboxCreationFixture(t *testing.T) (sandboxSupervisorFixture, string) {
+	t.Helper()
+	if os.Geteuid() != 0 {
+		t.Fatal("sandbox_root tests require root inside a disposable Linux mount/PID/network namespace")
+	}
+	cli := os.Getenv("PROFILE_BUNDLE_CLI")
+	if cli == "" {
+		t.Fatal("PROFILE_BUNDLE_CLI must name the prebuilt installer")
+	}
+	fixture := newSafeSandboxSupervisorFixture(t)
+	if err := os.Chmod(filepath.Join(fixture.profileStore, "sha256"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bundle := filepath.Join(filepath.Dir(fixture.sandboxRoot), "fixture.bundle")
+	probe, err := os.ReadFile(os.Getenv("SANDBOX_ROOT_PROBE"))
+	if err != nil {
+		t.Fatalf("SANDBOX_ROOT_PROBE must name the prebuilt conformance fixture: %v", err)
+	}
+	rootfs := writeIndependentRootFSFixture(t, "opt/python/bin/python3", probe)
+	digest := writeIndependentBundleFixtureWithRootFS(t, bundle, validFixtureLock(), validFixturePolicy(), rootfs)
+	command := exec.Command(cli, "install", "--bundle", bundle,
+		"--expected-sha256", digest, "--store", fixture.profileStore)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("install real Profile Bundle: %v\n%s", err, output)
+	}
+	return fixture, "sha256:" + digest
+}
+
+func sandboxProcessForRoot(t *testing.T, fixture sandboxSupervisorFixture, identity string) string {
+	t.Helper()
+	pids := sandboxProcessesForRoot(t, fixture, identity)
+	if len(pids) != 1 {
+		t.Fatalf("want one live process rooted in Profile, got %v", pids)
+	}
+	return pids[0]
+}
+
+func sandboxProcessesForRoot(t *testing.T, fixture sandboxSupervisorFixture, identity string) []string {
+	t.Helper()
+	root, err := os.Stat(filepath.Join(fixture.profileStore, "sha256", strings.TrimPrefix(identity, "sha256:"), "rootfs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pids []string
+	for _, entry := range entries {
+		info, err := os.Stat(filepath.Join("/proc", entry.Name(), "root"))
+		if err == nil && os.SameFile(info, root) {
+			pids = append(pids, entry.Name())
+		}
+	}
+	return pids
+}

--- a/tests/sandbox_supervisor_protocol_linux_test.go
+++ b/tests/sandbox_supervisor_protocol_linux_test.go
@@ -549,6 +549,7 @@ type sandboxSupervisorFixture struct {
 	socketPath   string
 	profileStore string
 	sandboxRoot  string
+	launchPrefix []string
 }
 
 func shortSandboxSupervisorTemporaryDirectory(t *testing.T) string {
@@ -686,7 +687,7 @@ func assertSandboxdRejectsStartup(
 	}
 }
 
-func startSandboxSupervisor(t *testing.T, fixture sandboxSupervisorFixture) func() {
+func startSandboxSupervisor(t *testing.T, fixture sandboxSupervisorFixture, extraArguments ...string) func() {
 	t.Helper()
 
 	commandPath := sandboxdCommandPath(t)
@@ -698,6 +699,11 @@ func startSandboxSupervisor(t *testing.T, fixture sandboxSupervisorFixture) func
 		"--profile-store", fixture.profileStore,
 		"--sandbox-root", fixture.sandboxRoot,
 	)
+	command.Args = append(command.Args, extraArguments...)
+	if len(fixture.launchPrefix) != 0 {
+		arguments := append(append([]string{}, fixture.launchPrefix[1:]...), command.Args...)
+		command = exec.Command(fixture.launchPrefix[0], arguments...)
+	}
 	command.Stdout = &output
 	command.Stderr = &output
 	if err := command.Start(); err != nil {
@@ -737,6 +743,8 @@ func startSandboxSupervisor(t *testing.T, fixture sandboxSupervisorFixture) func
 		case err := <-exited:
 			if err != nil {
 				t.Errorf("sandboxd exited after interrupt: %v\n%s", err, output.String())
+			} else if output.Len() != 0 {
+				t.Logf("sandboxd diagnostics:\n%s", output.String())
 			}
 		case <-time.After(5 * time.Second):
 			_ = command.Process.Kill()

--- a/tests/testdata/sandbox-root-probe/main_linux.go
+++ b/tests/testdata/sandbox-root-probe/main_linux.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+// This trusted conformance fixture is installed as the test Profile entrypoint.
+// The host harness enters the Sandbox namespaces with nsenter; sandboxd never
+// exposes a test-only execution operation or accepts this probe's arguments.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fail("expected the host-only marker path")
+	}
+	if os.Geteuid() != 0 {
+		fail("probe must exercise namespace root's filesystem privileges")
+	}
+	for _, prefix := range []string{"", "/../../../../", "/.oldroot", "/proc/1/root"} {
+		if _, err := os.ReadFile(prefix + os.Args[1]); !errors.Is(err, syscall.ENOENT) {
+			fail("host-only marker lookup returned %v, want ENOENT", err)
+		}
+	}
+	if err := os.WriteFile("/unexpected-write", []byte("not allowed"), 0o600); !errors.Is(err, syscall.EROFS) {
+		fail("root filesystem write returned %v, want EROFS", err)
+	}
+	fmt.Println("host-root-unreachable; profile-read-only")
+}
+
+func fail(format string, arguments ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", arguments...)
+	os.Exit(1)
+}


### PR DESCRIPTION
`create_sandbox` can now create a real Linux Sandbox when the operator configures reserved subordinate UID/GID ranges. Each active Sandbox gets a distinct identity block and a private, read-only Profile root installed through `pivot_root`; success is reported only after old-root detachment and descriptor cleanup. Startup without allocation configuration preserves the existing protocol-only behavior.

The change adds strict Profile directory ownership/path checks, bounded bootstrap readiness, failed-creation rollback, real-kernel acceptance tests, a dedicated Ubuntu CI job, and a Chinese implementation guide. A regression test covers shell-inherited host directory descriptors found during review.

This implements T04 creation only. The trusted bootstrap remains idle; Python Execution, production Sandbox Init, complete recovery, capability/seccomp enforcement, and Resource Budgets belong to later tickets.

Validation completed locally:

- Linux Go 1.26.1: formatting, `go vet ./...`, `go test ./...`, `go build ./...`, and Shell syntax checks passed as an ordinary user where required.
- All nine real-kernel Sandbox creation test groups passed on WSL2 Linux 5.15, including an in-namespace host-marker/read-only probe, concurrent identity allocation, kernel mapping rejection, and inherited-FD denial.
- Windows-applicable tests and vet passed.
- Standards and Spec reviews have no unresolved findings; the inherited-FD P1 was fixed and verified red-to-green.

GitHub CI runs Runtime Lab, Profile Bundle, and Sandbox creation checks. Reproduction and scope details are recorded in `docs/testing/t04-acceptance.md` and `docs/learning/t04-sandbox-creation.md`.

Closes #10.
