### PR TITLE
feat: implement T12 execution deadlines and safe Sandbox reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ T06 增加公开 `DestroySandbox` 调用，并处理执行中断连、Init 丢�
 
 T08 在 Python 启动前清空 Workload 的 capability 集合、设置不可撤销的 `no_new_privs`，并安装与 Profile Bundle 摘要绑定的 seccomp 白名单。策略仅支持 Linux amd64，检查完整 64 位参数，拒绝 namespace 创建、未审阅的 `clone` 标志和其他 syscall ABI；禁止调用返回 `EPERM`。真实 Linux 验收覆盖 Python 数据处理、线程与子进程继承、参数边界、策略篡改和拒绝后的复用。权限设置时机、白名单兼容问题和方案取舍见 [`T08 学习笔记`](docs/learning/t08-system-call-policy.md)。
 
-T09 使用持续存在的 Sandbox cgroup v2 父组执行 CPU、内存、swap 和 PID 资源预算，Init 与每次 Execution 使用独立子组。默认预算为 2 CPU、1 GiB 内存、禁用 swap、64 个内核任务，均由可信启动配置决定。内核 CPU 节流与内存/PID 超限分别报告；跨 Execution 留存的 Workspace 内存继续计入父预算。运行验收需要已委派 `cpu memory pids` 控制器的 cgroup v2 父目录，可通过 `SANDBOX_TEST_CGROUP_PARENT` 指定。原理、方案比较与代码阅读路线见 [`T09 学习笔记`](docs/learning/t09-resource-budgets.md)。T07、T10–T12 的后续安全及资源合同仍需完成，当前不能据此用于任意不可信 Workload。
+T09 使用持续存在的 Sandbox cgroup v2 父组执行 CPU、内存、swap 和 PID 资源预算，Init 与每次 Execution 使用独立子组。默认预算为 2 CPU、1 GiB 内存、禁用 swap、64 个内核任务，均由可信启动配置决定。内核 CPU 节流与内存/PID 超限分别报告；跨 Execution 留存的 Workspace 内存继续计入父预算。运行验收需要已委派 `cpu memory pids` 控制器的 cgroup v2 父目录，可通过 `SANDBOX_TEST_CGROUP_PARENT` 指定。原理、方案比较与代码阅读路线见 [`T09 学习笔记`](docs/learning/t09-resource-budgets.md)。
+
+T12 增加每次 Execution 的可信执行期限，默认 60 秒，可通过 `sandboxd --execution-timeout` 配置。超时后终止该次执行的全部后代，等待 Init 回收并移除 Execution cgroup，再返回 `timed_out`；清理成功时同一 Init 和 Workspace 可供后续执行复用。客户端取消和显式销毁仍终止整个 Sandbox。实现原理、替代方案、竞态与验证方法见 [`T12 学习笔记`](docs/learning/t12-execution-deadlines.md)。T07、T10–T11 的后续安全及资源合同仍需完成，当前不能据此用于任意不可信 Workload。
 
 ## 使用 Go Runtime Lab
 

--- a/cmd/sandboxd/main_linux.go
+++ b/cmd/sandboxd/main_linux.go
@@ -38,6 +38,7 @@ func run(arguments []string) error {
 	flags.Int64Var(&config.ResourceBudget.MemoryBytes, "memory-bytes", config.ResourceBudget.MemoryBytes, "Sandbox memory budget in bytes")
 	flags.Int64Var(&config.ResourceBudget.SwapBytes, "swap-bytes", config.ResourceBudget.SwapBytes, "Sandbox swap budget in bytes; zero prohibits swap")
 	flags.Int64Var(&config.ResourceBudget.PIDs, "pids-limit", config.ResourceBudget.PIDs, "Sandbox task budget (processes and threads)")
+	flags.DurationVar(&config.ResourceBudget.ExecutionTimeout, "execution-timeout", config.ResourceBudget.ExecutionTimeout, "wall-clock budget per Execution, independent of the Worker connection")
 	flags.UintVar(&config.SubUIDStart, "subuid-start", 0, "first operator-reserved subordinate host UID")
 	flags.UintVar(&config.SubGIDStart, "subgid-start", 0, "first operator-reserved subordinate host GID")
 	flags.UintVar(&config.SubIDCount, "subid-count", 0, "reserved IDs per UID/GID range, in blocks of 65536; zero disables creation")

--- a/docs/learning/t12-execution-deadlines.md
+++ b/docs/learning/t12-execution-deadlines.md
@@ -1,0 +1,232 @@
+# T12：执行超时后，怎样让同一个 Sandbox 继续工作
+
+T09 已经限制了 CPU、内存、swap 和 PID，但这些 cgroup 预算本身不能限制程序总共运行多久。原系统另有固定 60 秒的通信保护，保护到期会使 Sandbox 失效，无法交付一个可复用环境中的超时结果。T12 补上每次 Execution 的执行期限：可信 Supervisor 到期后终止该次 Execution 的全部进程，完成回收，再返回 `timed_out`。只要 Init 和清理握手正常，同一个 Sandbox 可以继续执行下一段 Python，Workspace 中已有的文件也保留。
+
+本文对应 [T12 / #18](https://github.com/TH1NKING/Build-your-own-Docker-with-Go/issues/18)，延续 [ADR-0014 的默认资源预算](../adr/0014-start-with-conservative-sandbox-resource-budgets.md) 与 [ADR-0016 的常驻 Init](../adr/0016-keep-one-sandbox-init-per-agent-run.md)。这次工作的核心，是把“期限到了”落实成一条有完成条件的清理流程。
+
+## 先看一个能解释项目价值的场景
+
+假设 Agent 先在 Workspace 生成了一份中间文件，随后运行的 Python 卡在死循环。平台需要终止这次计算，让 Agent 得到明确的超时结果，并继续使用之前生成的文件修正代码。
+
+这要求同时成立三件事：旧 Python 及其后代不能继续运行；可信 PID 1 仍然可用；下一次 Execution 开始时，旧执行的进程、输出管道和协议消息已经处理完毕。只是在 Go 函数里返回 `context deadline exceeded`，无法证明这些条件成立。
+
+你可以把最终演示组织成四步：写入 `state` 文件后开始死循环；收到 `timed_out`；检查旧 Execution 的 cgroup 已删除；在同一个 Sandbox 读回 `state`，同时确认 Init 的宿主 PID 没变。这样展示的是一次失败后的继续执行能力。
+
+## 这次改变了哪些合同
+
+| 位置 | 变化 | 为什么放在这里 |
+| --- | --- | --- |
+| `ResourceBudget.ExecutionTimeout` | 每次 Execution 获得有限执行时长，默认 60 秒 | 与其他可信资源预算统一配置 |
+| `sandboxd --execution-timeout` | Platform Operator 可以在启动 Supervisor 时配置时长 | Workload 和普通 Worker 请求不能自行延长期限 |
+| Execution 的等待流程 | 在发送 `run` 放行之前建立期限，到期进入整组终止与回收 | 避免不可信代码先运行、计时后启动的空档 |
+| `terminal_reason` | 新增 `timed_out` | 调用方能区分超时、普通退出和已有资源超限原因 |
+| 真实 Linux 验收 | 检查超时、后代清理、Init 存活与 Workspace 复用 | 返回一个错误或通过编译都不足以证明内核状态正确 |
+
+零或负时长不是“无限制”的简写，启动配置应直接拒绝。给每次请求增加一个可自由选择的 `timeout` 看起来方便，但会让普通调用方决定自己受多大的资源约束。未来如果需要分档，可以设计可信策略选择；当前公开请求保持封闭。
+
+## 三种等待时间不能混为一谈
+
+| 时间 | 谁负责 | 到期意味着什么 |
+| --- | --- | --- |
+| 客户端 context 的等待时间 | Worker 侧调用者 | 调用者不再继续等待；当前请求中断后，沿用 T06 的 Sandbox 终止规则 |
+| Execution 的执行期限 | Supervisor 的可信 Resource Budget | 结束当前 Workload 及全部后代；清理成功后允许复用 Sandbox |
+| Init 控制管道的通信保护 | Supervisor 的内部协议 | 可信组件没有按约定完成握手，无法继续把 Sandbox 当作正常状态 |
+
+T12 之前，执行代码里已有固定 60 秒的管道读写保护。它能避免 Supervisor 无限等待一条消息，但还不能表达“正常的执行超时结果，并保留 Sandbox”。将这一个数字改成配置值仍然不够：如果超时只导致读取失败，原有失败路径会终止 Init，使 Sandbox 整体失效。
+
+执行期限结束后，仍需要时间做 `cgroup.kill`、等待进程退出、让 Init 回收、读取结果和删除 cgroup。因此通信保护必须给这些步骤留出独立的收尾窗口。复用已经到期的读取期限，会使后续 `exited` 或 `ready` 消息即使正常产生，也无法被读取。
+
+本次为 Init 的启动与最终回收握手分别设置 5 秒保护；正式等待 Workload 时清除启动阶段的读取期限，触发终止后再给退出消息设置 5 秒保护。公开 Worker 连接的响应写入期限也改为在结果准备好后才开始计算，否则在接收请求时设置的旧 5 秒期限会让一次合法的较长 Execution 无法交付结果。
+
+同理，Workload 持续输出不应刷新执行期限。按最后一次输出重新计时适合“空闲超时”，但一段定期打印的死循环可以永远保持活跃，无法满足固定执行预算。
+
+## 为什么从 `run` 放行前开始计时
+
+一次 Execution 的启动顺序已经由 T05/T09 建立：创建 Execution cgroup，通知 Init 启动可信 launcher，launcher 在私有 gate 上等待；Supervisor 确认宿主 PID、完成归组并撤销继承的 OOM 保护，最后发送 `run` 才允许它执行 Python。
+
+T12 把期限建立在最后这个放行边界之前。这样，Python 启动和后续运行都处于同一段预算内，Workload 没有机会在计时开始前执行。前面的受信任准备工作由启动与通信保护约束，不需要把它含糊地混进 Python 的执行时长。
+
+采用 `time.Now().Add(timeout)` 保留 Go 的单调时钟信息，之后通过时间比较或剩余时长等待来测量持续时间。单调时钟适合回答“已经过了多久”，不会因为墙上时钟被校准就突然多出或少掉一段执行预算。把时间先转成 Unix 秒再算差值，会丢失这一点。[Go 的单调时钟说明](https://pkg.go.dev/time#hdr-Monotonic_Clocks)
+
+执行期限表示到期触发终止，客户端看到结果还包含调度、杀进程与回收的耗时。因此配置 `500ms` 不等于承诺 RPC 必定在第 500 毫秒返回。验收应检查没有提前到期，并给实际清理留下合理且有界的完成时间；它不是实时系统的精度测试。
+
+## 为什么用 Execution cgroup，而不是只杀一个 PID
+
+沿用 T09 的结构即可区分两个终止范围：
+
+```text
+Sandbox 预算父组
+├── Init 叶子：常驻可信 PID 1
+└── Execution 叶子：本次 Python 与它产生的全部后代
+```
+
+超时只向 Execution 叶子的 `cgroup.kill` 写入 `1`。Linux 对目标 cgroup 子树内的进程发出 `SIGKILL`，并处理终止过程中的并发 fork；它比在用户态先枚举 PID、再逐个发送信号更适合这个边界。[Linux cgroup.kill 合同](https://docs.kernel.org/admin-guide/cgroup-v2.html#core-interface-files)
+
+前提仍然是启动时正确归组，且 Workload 无权把自己迁出可信 Supervisor 管理的边界。不能把 cgroup 理解成无论怎么配置都能自动找到任意历史后代的追踪器。
+
+| 方案 | 适合的地方或优点 | 在本项目中的不足 |
+| --- | --- | --- |
+| 只取消 Go context | 让合作的 goroutine、I/O 和请求停止等待 | context 只是信号；需要代码把它转成进程终止与清理动作 |
+| 只 kill 主 Python PID | 目标直接，实现简单 | 后台子孙可能继续计算、写文件或持有输出管道 |
+| kill 进程组 | 适合由 shell 管理、遵守进程组约定的命令 | 子进程可改变进程组或创建新会话；进程组本身不是完整后代边界，参见 [setsid](https://man7.org/linux/man-pages/man2/setsid.2.html) |
+| 遍历 `/proc`，递归查找子进程再 kill | 便于观测与诊断进程关系 | 枚举与发送信号之间仍会 fork、退出或重新托管，快照容易失效 |
+| 终止 Sandbox Init | 在 Sandbox 整体结束或状态不可信时，提供统一终止路径 | PID 1 消失使该 PID namespace 无法继续创建进程，破坏同一 Sandbox 的复用合同 |
+| kill Execution cgroup | 用既有的内核成员边界覆盖本次执行及后代，同时保留 Init | 需要 cgroup v2、可信归组、权限配置，以及显式等待和回收 |
+
+这里使用直接 `SIGKILL`，不额外增加由 Workload 自愿退出的宽限阶段。它适合不可信代码的硬性终止策略。先发 `SIGTERM` 再等待，能让合作程序保存状态，但不可信 Workload 可以忽略它，平台也必须定义宽限时间算不算预算。直接终止的代价是 Python 的 `finally` 或退出清理不保证执行；保留 Workspace 不等于把未完成写入自动变成一致的事务。
+
+Init 的存活与 PID namespace 的可复用性由 Linux 的生命周期规则决定。Init 死亡后，该 namespace 中的其余进程会被终止，也不能通过重新启动另一个“PID 1”恢复原 namespace。[Linux PID namespace 的 Init 语义](https://man7.org/linux/man-pages/man7/pid_namespaces.7.html)
+
+## `kill`、退出、回收、可复用分别是什么
+
+```mermaid
+sequenceDiagram
+    participant S as Supervisor
+    participant I as 常驻 Init
+    participant W as Python 及后代
+    S->>S: 创建 Execution 叶子，完成归组
+    S->>S: 建立执行期限
+    S->>I: run
+    I->>W: 打开 gate
+    S->>S: 执行期限到达
+    S->>W: cgroup.kill = 1
+    S->>S: 等待 cgroup.events 的 populated 0
+    I-->>S: exited：主 Python 已退出
+    S->>I: reap
+    I->>I: 回收全部后代，排空输出
+    I-->>S: ready：本次结果已完整收集
+    S->>S: 删除 Execution 叶子
+    S-->>S: 返回 timed_out，释放执行权
+```
+
+图里的 `exited` 可能在观察到 `populated 0` 之前就已经进入管道；关键约束是它必须被本次 Execution 的读取者消费，且确认整组没有活进程之后才进入最终回收握手。
+
+这些阶段分别提供不同的证据：
+
+1. **`cgroup.kill` 写入成功**：内核接受了整组终止动作。
+2. **`populated 0`**：该组及子组已经没有活进程。它不是“所有退出状态都已回收”的证明。[Linux populated 的定义](https://docs.kernel.org/admin-guide/cgroup-v2.html#un-populated-notification)
+3. **消费 `exited`**：本次主 Python 的退出阶段已经到达，私有协议推进到了正确位置。
+4. **`reap → ready`**：Init 等到没有待回收子进程，并完成输出收集，可以接收下一次 `start`。
+5. **删除 Execution cgroup**：旧执行的内核管理对象已清理，才能交付可复用状态并释放执行权。
+
+`kill` 不负责回收。进程终止后，内核仍可能保留退出状态供父进程读取；父进程调用 wait 系列操作才完成这部分工作，否则会留下僵尸进程。[Linux wait 的回收语义](https://man7.org/linux/man-pages/man2/wait.2.html)
+
+Init 只让一条等待路径管理子进程退出状态，避免 `Process.Wait` 与 `Wait4(-1)` 互相抢走结果。等待主 Python 时可以顺便回收已退出后代；Supervisor 杀空 Execution 组后，再让 Init 等到 `ECHILD`，确认已经没有可回收的孩子。这是 T05 已有机制，T12 把超时接到同一条可信结束路径上。
+
+## 为什么超时后还要消费一次 `exited`
+
+Supervisor 同时等待期限和 Init 的退出消息。超时分支胜出时，负责读 `exited` 的 goroutine 可能仍在读取。此时若立刻再起一个读取者等 `ready`，两个读取者会共享同一条帧流，某一方可能读走另一方期待的消息。更糟的是，一个已经不再受管理的旧读取者可能影响下一次 Execution。
+
+因此，期限到达不代表可以抛弃当前读取者。实现先触发终止，用有界的通信保护等待这一条读取完成，随后再发送 `reap` 并读取 `ready`。如果等待函数因资源观察失败或 Sandbox 取消提前返回，会把当前读期限设为“现在”，唤醒阻塞读取并等它交回结果，然后才离开等待函数。这让旧 goroutine 不会跨过执行边界。
+
+这里只创建一个用于本次等待的 goroutine，比把每个协议阶段都拆成独立异步任务更容易建立所有权。它仍需要明确的结束条件；“启动到后台”不等于“已经有人负责清理”。
+
+## 正常退出和期限同时到达时怎么办
+
+设 Python 在期限附近退出，而 Supervisor 同时发现计时器已到期。Go 的 `select` 不承诺“代码写在前面的分支优先”，所以不能仅靠调换分支顺序来定义结果。[Go select 规范](https://go.dev/ref/spec#Select_statements)
+
+当前实现的裁决规则是：期限分支被选中后，先非阻塞检查本次 `exited` 读取是否已经完成；已经完成就优先消费这个结果。若没有已交付的读取结果，记下 `timedOut=true`，触发整组终止。正常退出分支直接收到结果时，则沿原有清理路径完成。
+
+这是一条以 Supervisor 观察为基础的边界规则。当前控制协议没有提供一个可直接比较的精确内核退出时刻，因此它不能还原“Python 恰好比期限早 1 纳秒退出”的事实。工作重点是不给同一次 Execution 产生两个结果、不让已消费的退出消息留给下一次执行，并在裁决后完成相同的清理条件。
+
+同一时刻还可能出现 OOM 或 PID 上限事件。本项目把 `SIGKILL` 终止映射为 `exit_code=137`，但程序也可以主动调用 `sys.exit(137)`，所以这个数字连“确实收到过 `SIGKILL`”都不能独立证明。即使确认了信号，超时、资源处理和显式销毁也都可能使用它。终止原因应来自 Supervisor 的期限状态和宿主资源证据，不能从退出码猜测。
+
+最终主原因的优先级沿用资源证据优先的规则：`memory_limit` → `pids_limit` → `timed_out` → `exited`。例如，已经触发超时，同时读到本次 OOM 事件增量，结果选择 `memory_limit`，同时保留资源统计。这个顺序是平台对重叠证据的分类政策，不能据此断言 OOM 在时间上一定先于期限。
+
+## 哪些失败会使整个 Sandbox 失效
+
+可复用要求 Init 仍然可信并且清理成功。如果 `exited` 缺失、`ready` 失序、控制管道失效，或 cgroup 无法可靠清理，就不能为了保住 Workspace 而继续接收下一次执行。旧状态不确定时，新的 Python 可能与旧后代重叠，也可能读到错误的协议消息。
+
+现有失败路径终止 Init，进入 T06 的 Sandbox 整体收尾。清理未成功的资源仍由 Sandbox 持有，以便现有销毁流程继续处理；返回某个有证据的终止原因，也不代表可以跳过清理确认。
+
+取消沿用同样的生命周期边界：客户端中途放弃已经取得所有权的请求，显式调用 `DestroySandbox`，或 Supervisor 关闭，都会终止整个 Sandbox。T12 没有新增“只取消本次 Execution，并保持 Sandbox”的公开 RPC。实现这样的细粒度取消还要处理请求身份、取消与完成竞态，以及调用方如何确认结果，不能用客户端 context 偷偷代替这份合同。
+
+## 按这个顺序读代码
+
+| 顺序 | 文件 | 带着什么问题阅读 |
+| --- | --- | --- |
+| 1 | [资源预算](../../internal/sandboxsupervisor/resource_budget_linux.go)、[启动入口](../../cmd/sandboxd/main_linux.go) | 谁能配置期限，默认值和非法输入是什么？ |
+| 2 | [Execution 流程](../../internal/sandboxsupervisor/execution_linux.go) | 计时何时开始，到期谁负责 kill，谁拥有响应读取？ |
+| 3 | [cgroup 管理](../../internal/sandboxsupervisor/cgroup_linux.go) | 如何确认没有活进程，删除失败后谁还持有资源？ |
+| 4 | [Init 协议](../../internal/sandboxsupervisor/init_linux.go) | `exited` 和 `ready` 各自承诺什么，为什么还要 `reap`？ |
+| 5 | [公开结果](../../internal/sandboxsupervisor/protocol.go) | 终止原因与退出码为什么是不同字段？ |
+| 6 | [生命周期](../../internal/sandboxsupervisor/lifecycle_linux.go) | 超时为何可以保留 Sandbox，断线取消为何仍整体结束？ |
+| 7 | [期限验收](../../tests/sandbox_deadline_linux_test.go)、[执行失败验收](../../tests/sandbox_execution_failure_linux_test.go) | 哪些断言证明后代已清理，哪些证明环境确实被复用？ |
+
+第一遍只追“死循环到期，但 Init 正常”的路径。第二遍假设 Init 不再回复，观察哪些状态不再允许复用。最后再读正常退出与期限竞态，容易看清每一个错误处理为何存在。
+
+## 在 Ubuntu 上怎样验证
+
+真实进程与 cgroup 行为需要 Linux 验收。仓库提供的 [执行测试脚本](../../tests/run-sandbox-init-linux.sh) 会构建 Supervisor、Init 与测试程序，并在独立 mount/PID/network namespace 中安装 Python Profile 运行场景。Profile 源码缓存、root 权限与 cgroup 委派的准备方法见 [Supervisor 配置合同](../sandbox-supervisor-protocol-v1.md) 和 [T05 学习笔记](t05-sandbox-init.md)。
+
+在已经准备好上述条件的 Ubuntu 仓库根目录，先运行配置和协议的普通检查，再执行真实 Linux 场景：
+
+```bash
+make check
+
+SANDBOX_TEST_RUN='^TestSandboxExecutionDeadline' \
+  bash tests/run-sandbox-init-linux.sh
+
+bash tests/run-sandbox-init-linux.sh
+```
+
+普通 `go test ./...` 不会自动包含带 `sandbox_root,profilebundle_root` 标签的内核验收。只看普通测试通过，就无法判断 `cgroup.kill` 是否真的生效。
+
+重点检查这些证据：
+
+| 场景 | 应观察的结果 |
+| --- | --- |
+| 客户端给 10 秒，Supervisor 给 500 毫秒，Python 死循环 | 客户端仍在等待时收到 `timed_out`，证明期限来自 Supervisor |
+| Python 先写 Workspace，再超时 | 下一次执行读取到文件，Init 的宿主 PID 与之前一致 |
+| Workload 留下子孙进程或持有输出管道 | 结果返回前后代被清理，下一次执行只能看见 Init 和当前 Python |
+| Python 在期限前正常退出 | 返回 `exited`，下一次执行不受旧计时器或旧协议消息影响 |
+| Workload 持续输出 | 输出活跃不会延长期限；仍然经过同一条终止与收尾路径 |
+| Init 丢失或清理失败 | Sandbox 失效，后续执行被拒绝，不把不确定状态交付为可复用环境 |
+
+这些是验收目标。某一场景是否已经有测试覆盖、用了什么内核与工具链、实际命令的结果，应以本节最后的验证记录为准。不要将“建议观测”当成“已经实测”。
+
+## 面试时怎么讲，怎么检验自己真的理解了
+
+可以先用这一段概括：我给自研 Sandbox 实现了可信的单次执行期限。超时后由宿主 Supervisor 终止 Execution cgroup 中的 Python 和全部后代，再等待 cgroup 没有活进程、Init 完成回收与输出收集、旧 cgroup 删除，才允许下一次执行。这样可以保留同一个 Init 和 Workspace；如果握手或清理不能确认，则让 Sandbox 整体失效。
+
+随后挑一条时序推演，而不是罗列技术名词。下面几个问题能检验你是否理解了取舍：
+
+1. **我给 HTTP 请求加了 `context.WithTimeout`，为什么 Python 还可能运行？** 解释等待取消与操作系统进程终止之间需要显式连接，随后说明后代范围和 wait 回收。
+2. **Python 父进程已经退出，但孙进程还持有 stdout，结果收集会怎样？** 先结束全部后代，再排空输出；若先无限等 EOF，就可能永远拿不到结果。
+3. **为什么 `populated 0` 后仍然需要 Init 回复 `ready`？** 区分没有活进程、没有待回收退出状态、输出已收集以及协议可继续四件事。
+4. **期限与正常退出同时就绪，调换 `select` 分支能否固定结果？** 不能；应依据明确的完成边界与可信证据处理竞态。
+5. **为何超时保留 Workspace，取消却销毁 Sandbox？** 前者是有完整清理协议的单次执行结果；后者沿用 T06 的请求所有权与 Sandbox 生命周期合同。
+6. **每次最多 60 秒，是否意味着整个 Agent Run 最多 10 分钟？** 不意味着。Agent Run 可以有多次 Execution，也包含模型调用、排队和暂停；累计预算需要上层跟踪与独立的计时范围。
+
+可以再做一个练习：画出“收到超时后立即释放执行锁”的时序，尝试找出第二次 Execution 会撞上什么旧状态。至少应找到旧后代仍写文件、旧响应读取者仍在运行、旧输出还未收集三个风险。
+
+简历可以写已经被测试证明的行为，例如“实现基于 cgroup v2 的执行期限与后代回收，支持超时后复用 Sandbox Init 和 Workspace”。终止延迟、连续复用次数、残留进程数等数据应实际测量后再补，不能把测试中的容忍窗口写成性能成绩。
+
+T12 只处理每次 Execution 的执行期限；T29 的 Agent Run 累计时间、T11 的完整有界输出结果合同，以及跨 Supervisor 重启的恢复不在这次范围内。
+
+## 本次验证记录
+
+开发期间已在用户提供的 Ubuntu 24.04.4 虚拟机、Linux `7.0.0-30-generic`、Go `1.26.1` 下，将 `TestSandboxExecutionDeadlinePreservesInitAndWorkspace` 从失败推进到通过。该项确认：可信 500 毫秒期限独立于客户端 10 秒等待；返回 `timed_out`、退出码 `137` 并保留已捕获的 `started` 输出；返回前删除 Execution 叶子；下一次执行继续使用相同 Init 和之前的 Workspace 文件。
+
+随后完成的定向 Linux 验收包括：
+
+- 连续三轮超时后复用同一个 Sandbox；Workload 持续写 stdout/stderr，并产生通过 `setsid` 脱离原会话的孙进程，验证后代与输出管道被清理。
+- 执行中并发销毁与客户端断连取消，确认全部后代终止及 cgroup 清理。
+- PID Resource Budget 的既有回归场景。
+- 将 Init 置于 `SIGSTOP` 状态，使其无法回复；期限与通信保护促使 Sandbox 在约 6.51 秒后失效并收尾，之后可创建新的 Sandbox。该耗时是这次场景的观测值，不是一般性能保证。
+- 可信 90 秒期限配置、零与负时长拒绝，以及公开请求尝试覆盖期限时的拒绝。
+
+2026-09-07 完成最终验证：
+
+| 验证 | 结果 |
+| --- | --- |
+| 默认 60 秒期限 | 真实等待后返回 `timed_out`，同一 Sandbox 可继续执行 |
+| 配置 75 秒，Python 正常运行 66 秒 | 返回 `exited` 并交付完整结果，未被旧 60/65 秒通信保护截断 |
+| 普通 `sys.exit(137)` | 返回 `exited`，不从退出码误判超时 |
+| `make check` | 格式、静态分析、普通测试、构建和 Shell 语法检查全部通过 |
+| 完整 `^TestSandbox(Execution\|Lifecycle)` 内核验收 | 31 个顶层测试全部通过，包含现有 seccomp、资源预算及生命周期回归 |
+| Supervisor 与测试程序启用 `-race` | 5 个定向测试全部通过，覆盖超时复用、持续输出后代、Init 无响应、并发销毁和断连取消；未报告数据竞争 |
+| Standards 审查 | 0 项需要修改的问题 |
+| Spec 审查 | 0 项缺失、越界或实现错误问题 |
+
+完整内核验收中的默认期限与长执行测试分别耗时约 60.50 秒和 66.44 秒，这包含测试准备与收尾，不能当作执行终止延迟。测试机与 Windows 上待提交源码包的 SHA-256 一致，确保验证使用的是本次实现副本。虚拟机的测试目录独立于原项目；验收所需临时 sudo 规则在验证完成后移除。

--- a/docs/sandbox-supervisor-protocol-v1.md
+++ b/docs/sandbox-supervisor-protocol-v1.md
@@ -74,6 +74,7 @@ Trusted Resource Budget flags (defaults shown) are:
 --memory-bytes 1073741824
 --swap-bytes 0
 --pids-limit 64
+--execution-timeout 1m
 ```
 
 CPU uses a fixed 100,000-microsecond period; 2000 millicores produces
@@ -81,6 +82,9 @@ CPU uses a fixed 100,000-microsecond period; 2000 millicores produces
 or Execution duration. CPU values must be at least 10 millicores and fit the
 quota conversion. Memory must be positive, swap nonnegative, and both must be
 whole memory pages; PID count must be positive. Invalid budgets fail startup.
+Execution timeout is a positive Go duration (for example `500ms` or `75s`);
+zero and negative durations are rejected. It is trusted startup policy, never
+a Worker request or Workload override.
 Budgets include Init and Workload tasks (including threads), and surviving
 Workspace tmpfs charges remain under the same parent across Executions.
 Very small valid policies may be insufficient to start or keep Init alive;
@@ -106,8 +110,10 @@ rejected before its payload is read or allocated. Connections have a bounded
 deadline, and the Supervisor serves up to 16 control connections concurrently
 so an incomplete client cannot block unrelated requests. T05 permits bounded
 Python source, stdin and output in the control frame; bulk file transfer remains
-outside this protocol. Reading a request has a five-second deadline. Executions
-have a 60-second private transport guard and a 65-second response write deadline.
+outside this protocol. Reading a request has a five-second deadline. Writing a
+response has a separate five-second window beginning when the result is ready.
+Neither window supplies the Execution deadline. Init startup and final
+reap/readiness handshakes have separate five-second transport guards.
 
 JSON decoding is strict. Unknown fields, duplicate fields, trailing values,
 invalid UTF-8, missing required fields, and malformed JSON are rejected.
@@ -313,6 +319,39 @@ resource reason with `exit_code=-1`, empty streams and `truncated=true` to
 indicate unavailable output/status; that Sandbox is invalidated and torn down.
 Usable Init state and complete cleanup are required for sequential reuse.
 
+T12 adds `timed_out`. The Supervisor establishes one monotonic deadline just
+before sending `run` to release the trusted launcher, including Python startup
+and all subsequent Workload activity. It defaults to 60 seconds and does not
+depend on the client connection's deadline or reset on output. Trusted launcher
+preparation uses the separate startup guard. The deadline initiates termination;
+the response also waits for bounded process cleanup and Init acknowledgement,
+so it is not a real-time guarantee of RPC completion at exactly that instant.
+
+On expiry, the Supervisor kills only the Execution cgroup, waits for no live
+descendants, consumes `exited`, completes `reap`/`ready`, and removes the child
+cgroup before allowing another Execution. Init and Workspace survive this
+successful timeout cleanup. Continuous output, `setsid`, and detached descendants
+do not extend the deadline. The private response pipe's startup deadline is
+cleared while the Workload runs; termination starts a fresh five-second exit
+guard, and the final reap handshake gets its own guard. There is exactly one
+reader for `exited`; an error path interrupts and joins it before returning.
+
+If a complete `exited` read is already available when the deadline branch runs,
+it is consumed as normal completion. Otherwise the Supervisor records its
+timeout decision before terminating the group. This is an observation rule,
+not a reconstruction of an exact kernel exit timestamp. Final classification
+uses `memory_limit`, then `pids_limit`, then `timed_out`, then `exited`, retaining
+all resource counters. Exit code 137 alone proves none of these reasons; a
+Workload can also return that code itself. If a timeout is established but Init
+cannot complete its handshake, `timed_out` is returned with `exit_code=-1`,
+empty streams and `truncated=true`, and the Sandbox is invalidated. Failed
+cgroup cleanup remains an error and never authorizes reuse.
+
+Cancellation preserves T06 semantics: client abandonment, `destroy_sandbox`,
+and Supervisor shutdown terminate the entire Sandbox and clean its cgroup tree.
+T12 adds no separate Execution cancellation operation or cumulative Agent Run
+time accounting; the latter remains T29.
+
 ## Creation and lifetime boundary
 
 The Supervisor opens the selected root-owned, immutable Profile through its
@@ -414,8 +453,8 @@ or promise cross-restart idempotency. T09 adds Sandbox cgroup Resource Budgets
 but no crash-recovery contract. Cgroup cleanup failures retain owned handles
 and the Sandbox identity reservation for a later `destroy_sandbox` retry;
 successful destruction waits for removal of the Execution, Init, and budget
-groups. Complete mount, storage, output and
-deadline enforcement remain T07 and T10–T12. This is not the complete
+groups. Complete mount, storage and output
+enforcement remain T07 and T10–T11. This is not the complete
 production security boundary.
 
 ## Verification

--- a/internal/sandboxsupervisor/execution_linux.go
+++ b/internal/sandboxsupervisor/execution_linux.go
@@ -20,6 +20,8 @@ type executePythonParameters struct {
 	Stdin       string `json:"stdin"`
 }
 
+const initTransportTimeout = 5 * time.Second
+
 func (service *server) executePythonResponse(operation *controlOperation, requestID string, raw json.RawMessage) responseEnvelope {
 	var parameters executePythonParameters
 	if err := decodeStrictJSON(raw, &parameters, "sandbox_id", "execution_id", "source", "stdin"); err != nil || parameters.Source == "" || strings.ContainsRune(parameters.Source, 0) || len(parameters.Source) > 32<<10 || len(parameters.Stdin) > 8<<10 {
@@ -81,11 +83,9 @@ func (creator *sandboxCreator) execute(operation *controlOperation, parameters e
 	if err != nil {
 		return nil, ErrorCodeOperationUnavailable
 	}
-	// A bounded transport guard until the configurable Execution deadline
-	// contract is implemented. This is never renewed by Workload activity.
-	deadline := time.Now().Add(60 * time.Second)
-	_ = sandbox.requests.SetWriteDeadline(deadline)
-	_ = sandbox.responses.SetReadDeadline(deadline)
+	if err := setInitTransportDeadline(sandbox); err != nil {
+		return nil, ErrorCodeExecutionFailed
+	}
 	if err := sendInitRequest(sandbox.requests, initRequest{Action: "start", Source: parameters.Source, Stdin: parameters.Stdin}); err != nil {
 		return nil, ErrorCodeExecutionFailed
 	}
@@ -103,10 +103,16 @@ func (creator *sandboxCreator) execute(operation *controlOperation, parameters e
 	if err := setProcessOOMScore(hostPID, 0); err != nil {
 		return nil, ErrorCodeExecutionFailed
 	}
+	// Start one monotonic deadline just before releasing the trusted launcher.
+	// Its expiry kills only this Execution, never the persistent Init context.
+	if err := sandbox.responses.SetReadDeadline(time.Time{}); err != nil {
+		return nil, ErrorCodeExecutionFailed
+	}
+	executionDeadline := time.Now().Add(creator.config.ResourceBudget.ExecutionTimeout)
 	if err := sendInitRequest(sandbox.requests, initRequest{Action: "run"}); err != nil {
 		return nil, ErrorCodeExecutionFailed
 	}
-	waitErr := waitBudgetedExecution(sandbox, group, before)
+	timedOut, waitErr := waitBudgetedExecution(sandbox, group, before, executionDeadline)
 	if err := group.killAndWait(); err != nil {
 		return nil, ErrorCodeExecutionFailed
 	}
@@ -123,8 +129,13 @@ func (creator *sandboxCreator) execute(operation *controlOperation, parameters e
 		reason = ExecutionMemoryLimit
 	} else if usage.PIDLimitEvents != 0 {
 		reason = ExecutionPIDLimit
+	} else if timedOut {
+		reason = ExecutionTimedOut
 	}
 	if waitErr != nil {
+		return incompleteResourceResult(parameters.ExecutionID, reason, usage)
+	}
+	if err := setInitTransportDeadline(sandbox); err != nil {
 		return incompleteResourceResult(parameters.ExecutionID, reason, usage)
 	}
 	if err := sendInitRequest(sandbox.requests, initRequest{Action: "reap"}); err != nil {
@@ -146,8 +157,8 @@ func incompleteResourceResult(executionID string, reason ExecutionTerminalReason
 	if reason == ExecutionExited {
 		return nil, ErrorCodeExecutionFailed
 	}
-	// Host kernel evidence survives loss of Init, but its exit status and
-	// captured output do not. Never manufacture an exit code from an OOM.
+	// Host budget evidence survives loss of Init, but its exit status and
+	// captured output do not. Never manufacture an exit code from that evidence.
 	// The caller's failed-handshake teardown invalidates this Sandbox.
 	return &ExecutePythonResult{ExecutionID: executionID, ExitCode: -1, Truncated: true, TerminalReason: reason, ResourceUsage: usage}, ""
 }
@@ -164,29 +175,74 @@ func setProcessOOMScore(pid, score int) error {
 	return nil
 }
 
-func waitBudgetedExecution(sandbox *createdSandbox, group *cgroup, before ExecutionResourceUsage) error {
+func setInitTransportDeadline(sandbox *createdSandbox) error {
+	deadline := time.Now().Add(initTransportTimeout)
+	if err := sandbox.requests.SetWriteDeadline(deadline); err != nil {
+		return err
+	}
+	return sandbox.responses.SetReadDeadline(deadline)
+}
+
+func waitBudgetedExecution(sandbox *createdSandbox, group *cgroup, before ExecutionResourceUsage, deadline time.Time) (bool, error) {
 	exited := make(chan error, 1)
 	go func() {
 		_, err := receiveInitResponse(sandbox.responses, "exited")
 		exited <- err
 	}()
+	received := false
+	defer func() {
+		if !received {
+			// Join the sole pipe reader on every error path before cleanup or
+			// another handshake can consume bytes from this same Init channel.
+			_ = sandbox.responses.SetReadDeadline(time.Now())
+			<-exited
+		}
+	}()
+	timer := time.NewTimer(time.Until(deadline))
+	defer timer.Stop()
+	deadlineReached := timer.C
 	ticker := time.NewTicker(10 * time.Millisecond)
 	defer ticker.Stop()
 	terminated := false
+	timedOut := false
+	terminate := func() error {
+		terminated = true
+		deadlineReached = nil
+		// Killing and collecting the result get a separate guard. An expired
+		// execution deadline must not interrupt Init's exit/reap handshake.
+		if err := sandbox.responses.SetReadDeadline(time.Now().Add(initTransportTimeout)); err != nil {
+			return err
+		}
+		return group.killAndWait()
+	}
 	for {
 		select {
 		case err := <-exited:
-			return err
+			received = true
+			return timedOut, err
+		case <-sandbox.ctx.Done():
+			return timedOut, sandbox.ctx.Err()
+		case <-deadlineReached:
+			// Prefer a complete exit already observed at the deadline boundary.
+			select {
+			case err := <-exited:
+				received = true
+				return timedOut, err
+			default:
+			}
+			timedOut = true
+			if err := terminate(); err != nil {
+				return timedOut, err
+			}
 		case <-ticker.C:
 			after, err := sandbox.cgroups.budget.resourceEvents()
 			if err != nil || after.OOMEvents < before.OOMEvents || after.PIDLimitEvents < before.PIDLimitEvents {
-				return errors.New("cannot observe Execution Resource Budget")
+				return timedOut, errors.New("cannot observe Execution Resource Budget")
 			}
 			if (after.OOMEvents > before.OOMEvents || after.PIDLimitEvents > before.PIDLimitEvents) && !terminated {
-				if err := group.killAndWait(); err != nil {
-					return err
+				if err := terminate(); err != nil {
+					return timedOut, err
 				}
-				terminated = true
 			}
 		}
 	}

--- a/internal/sandboxsupervisor/protocol.go
+++ b/internal/sandboxsupervisor/protocol.go
@@ -77,6 +77,7 @@ const (
 	ExecutionExited      ExecutionTerminalReason = "exited"
 	ExecutionMemoryLimit ExecutionTerminalReason = "memory_limit"
 	ExecutionPIDLimit    ExecutionTerminalReason = "pids_limit"
+	ExecutionTimedOut    ExecutionTerminalReason = "timed_out"
 )
 
 type ExecutionResourceUsage struct {

--- a/internal/sandboxsupervisor/resource_budget_linux.go
+++ b/internal/sandboxsupervisor/resource_budget_linux.go
@@ -6,19 +6,21 @@ import (
 	"errors"
 	"math"
 	"os"
+	"time"
 )
 
 // ResourceBudget is trusted Supervisor startup policy. Workloads and Worker
 // requests cannot select or override these finite Sandbox allowances.
 type ResourceBudget struct {
-	CPUMillis   int64
-	MemoryBytes int64
-	SwapBytes   int64
-	PIDs        int64
+	CPUMillis        int64
+	MemoryBytes      int64
+	SwapBytes        int64
+	PIDs             int64
+	ExecutionTimeout time.Duration
 }
 
 func DefaultResourceBudget() ResourceBudget {
-	return ResourceBudget{CPUMillis: 2000, MemoryBytes: 1 << 30, SwapBytes: 0, PIDs: 64}
+	return ResourceBudget{CPUMillis: 2000, MemoryBytes: 1 << 30, SwapBytes: 0, PIDs: 64, ExecutionTimeout: 60 * time.Second}
 }
 
 func (budget ResourceBudget) validate() error {
@@ -34,6 +36,9 @@ func (budget ResourceBudget) validate() error {
 	}
 	if budget.PIDs <= 0 {
 		return errors.New("Resource Budget PIDs must be positive")
+	}
+	if budget.ExecutionTimeout <= 0 {
+		return errors.New("Resource Budget Execution timeout must be positive")
 	}
 	return nil
 }

--- a/internal/sandboxsupervisor/server_linux.go
+++ b/internal/sandboxsupervisor/server_linux.go
@@ -149,11 +149,11 @@ func (service *server) handle(connection *net.UnixConn) {
 		service.writeProtocolError(connection, "", ErrorCodeMalformedRequest)
 		return
 	}
-	if request.Operation == OperationExecutePython {
-		_ = connection.SetWriteDeadline(time.Now().Add(65 * time.Second))
-	}
 	operation := beginControlOperation(service.creator.ctx, connection)
 	response := service.responseForRequest(operation, request)
+	// Response delivery has its own bounded window, regardless of the
+	// configured Execution duration or time spent cleaning its descendants.
+	_ = connection.SetWriteDeadline(time.Now().Add(5 * time.Second))
 	// Serialize successful delivery with disconnect handling. A client that
 	// closes immediately after reading the response must not cancel a Sandbox
 	// already handed back for later sequential Executions.

--- a/tests/sandbox_deadline_linux_test.go
+++ b/tests/sandbox_deadline_linux_test.go
@@ -1,0 +1,201 @@
+//go:build linux && sandbox_root && profilebundle_root
+
+package workspace_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/TH1NKING/Build-your-own-Docker-with-Go/internal/sandboxsupervisor"
+)
+
+func TestSandboxExecutionDeadlinePreservesInitAndWorkspace(t *testing.T) {
+	fixture, identity := installedSandboxExecutionFixture(t)
+	t.Cleanup(startSandboxSupervisor(t, fixture,
+		"--subuid-start", "200000", "--subgid-start", "300000", "--subid-count", "65536",
+		"--cgroup-root", os.Getenv("SANDBOX_CGROUP_ROOT"), "--execution-timeout", "500ms"))
+	assertSandboxCreated(t, exchangeSandboxSupervisorMessage(t, fixture.socketPath,
+		createSandboxWireRequest(t, "create", "run-deadline", identity)), "run-deadline")
+	initPID := sandboxProcessForRoot(t, fixture, identity)
+	initGroup := observedResourceCgroup(t, initPID)
+	client := sandboxsupervisor.NewClient(fixture.socketPath)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	started := time.Now()
+	response, err := client.ExecutePython(ctx, sandboxsupervisor.ExecutePythonRequest{
+		RequestID: "loop", SandboxID: "run-deadline", ExecutionID: "loop",
+		Source: "open('state', 'w').write('preserved'); print('started', flush=True)\nwhile True: pass",
+	})
+	elapsed := time.Since(started)
+	if err != nil || response.Error != nil || response.Result == nil {
+		t.Fatalf("deadline must return an Execution Result while the client remains connected: %+v, %v", response, err)
+	}
+	if result := response.Result; result.TerminalReason != "timed_out" || result.ExitCode != 137 || result.Stdout != "started\n" {
+		t.Fatalf("deadline lost its reason or captured output: %+v", result)
+	}
+	if elapsed < 500*time.Millisecond || elapsed > 5*time.Second || ctx.Err() != nil {
+		t.Fatalf("trusted 500ms deadline was not enforced independently of the 10s client context: %s, %v", elapsed, ctx.Err())
+	}
+	children, err := os.ReadDir(filepath.Dir(initGroup))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, child := range children {
+		if child.IsDir() && child.Name() != filepath.Base(initGroup) {
+			t.Fatalf("deadline result acknowledged before removing Execution cgroup %s", child.Name())
+		}
+	}
+	clean := executeSandboxPython(t, fixture, "run-deadline", "clean", `import os
+assert open('state').read() == 'preserved'
+assert set(n for n in os.listdir('/proc') if n.isdigit()) == {'1', str(os.getpid())}
+print('clean')`)
+	if clean.ExitCode != 0 || clean.TerminalReason != "exited" || clean.Stdout != "clean\n" {
+		t.Fatalf("timeout poisoned sequential reuse: %+v", clean)
+	}
+	if pid := sandboxProcessForRoot(t, fixture, identity); pid != initPID {
+		t.Fatalf("timeout replaced Init %s with %s", initPID, pid)
+	}
+	ordinary := executeSandboxPython(t, fixture, "run-deadline", "exit-137", "import sys; sys.exit(137)")
+	if ordinary.ExitCode != 137 || ordinary.TerminalReason != "exited" {
+		t.Fatalf("ordinary exit code was mistaken for deadline termination: %+v", ordinary)
+	}
+}
+
+func TestSandboxExecutionDeadlineKillsDetachedOutputWritersBeforeRepeatedReuse(t *testing.T) {
+	fixture, identity := installedSandboxExecutionFixture(t)
+	t.Cleanup(startSandboxSupervisor(t, fixture,
+		"--subuid-start", "200000", "--subgid-start", "300000", "--subid-count", "65536",
+		"--cgroup-root", os.Getenv("SANDBOX_CGROUP_ROOT"), "--execution-timeout", "1s"))
+	assertSandboxCreated(t, exchangeSandboxSupervisorMessage(t, fixture.socketPath,
+		createSandboxWireRequest(t, "create", "run-writers", identity)), "run-writers")
+	for range 3 {
+		result := executeSandboxPython(t, fixture, "run-writers", "flood", `import os, signal, time
+r, w = os.pipe()
+if os.fork() == 0:
+    os.close(r)
+    os.setsid()
+    if os.fork() != 0: os._exit(0)
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    os.write(w, b'R')
+    os.close(w)
+    while True:
+        os.write(1, b'x' * 8192)
+        os.write(2, b'y' * 8192)
+os.close(w)
+assert os.read(r, 1) == b'R'
+os.close(r)
+while True: time.sleep(60)`)
+		if result.TerminalReason != "timed_out" || result.ExitCode != 137 || !result.Truncated ||
+			len(result.Stdout) != 4096 || len(result.Stderr) != 4096 {
+			t.Fatalf("continuous detached writers escaped the deadline or lost output: %+v", result)
+		}
+		clean := executeSandboxPython(t, fixture, "run-writers", "clean", `import os
+assert set(n for n in os.listdir('/proc') if n.isdigit()) == {'1', str(os.getpid())}
+print('no-descendants-or-zombies')`)
+		if clean.TerminalReason != "exited" || clean.ExitCode != 0 || clean.Stdout != "no-descendants-or-zombies\n" {
+			t.Fatalf("old timeout, reader, or descendants disturbed a later Execution: %+v", clean)
+		}
+	}
+}
+
+func TestSandboxExecutionDeadlineDefaultAndLongerTrustedBudget(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		flags    []string
+		source   string
+		minimum  time.Duration
+		reason   sandboxsupervisor.ExecutionTerminalReason
+		exitCode int
+	}{
+		{"default-60s", nil, "print('ready', flush=True); import time; time.sleep(90)", 60 * time.Second, "timed_out", 137},
+		{"beyond-old-transport-guard", []string{"--execution-timeout", "75s"}, "import time; time.sleep(66); print('ready')", 66 * time.Second, "exited", 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture, identity := installedSandboxExecutionFixture(t)
+			flags := []string{"--subuid-start", "200000", "--subgid-start", "300000", "--subid-count", "65536", "--cgroup-root", os.Getenv("SANDBOX_CGROUP_ROOT")}
+			t.Cleanup(startSandboxSupervisor(t, fixture, append(flags, test.flags...)...))
+			assertSandboxCreated(t, exchangeSandboxSupervisorMessage(t, fixture.socketPath,
+				createSandboxWireRequest(t, "create", "run-long", identity)), "run-long")
+			ctx, cancel := context.WithTimeout(context.Background(), 85*time.Second)
+			defer cancel()
+			started := time.Now()
+			response, err := sandboxsupervisor.NewClient(fixture.socketPath).ExecutePython(ctx, sandboxsupervisor.ExecutePythonRequest{
+				RequestID: "long", SandboxID: "run-long", ExecutionID: "long", Source: test.source,
+			})
+			elapsed := time.Since(started)
+			if err != nil || response.Error != nil || response.Result == nil {
+				t.Fatalf("configured deadline was confused with transport failure: %+v, %v", response, err)
+			}
+			if result := response.Result; result.TerminalReason != test.reason || result.ExitCode != test.exitCode || result.Stdout != "ready\n" {
+				t.Fatalf("unexpected long Execution outcome: %+v", result)
+			}
+			if elapsed < test.minimum || elapsed > test.minimum+10*time.Second {
+				t.Fatalf("Execution lasted %s, want at least %s with bounded cleanup", elapsed, test.minimum)
+			}
+			clean := executeSandboxPython(t, fixture, "run-long", "clean", "print('still-ready')")
+			if clean.ExitCode != 0 || clean.Stdout != "still-ready\n" {
+				t.Fatalf("response delivery invalidated the long-lived Sandbox: %+v", clean)
+			}
+		})
+	}
+}
+
+func TestSandboxExecutionDeadlineInvalidatesUnresponsiveInit(t *testing.T) {
+	fixture, identity := installedSandboxExecutionFixture(t)
+	t.Cleanup(startSandboxSupervisor(t, fixture,
+		"--subuid-start", "200000", "--subgid-start", "300000", "--subid-count", "65536",
+		"--cgroup-root", os.Getenv("SANDBOX_CGROUP_ROOT"), "--execution-timeout", "1s"))
+	assertSandboxCreated(t, exchangeSandboxSupervisorMessage(t, fixture.socketPath,
+		createSandboxWireRequest(t, "create", "run-unresponsive", identity)), "run-unresponsive")
+	initPID := sandboxProcessForRoot(t, fixture, identity)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	client := sandboxsupervisor.NewClient(fixture.socketPath)
+	finished := make(chan sandboxsupervisor.ExecutePythonResponse, 1)
+	go func() {
+		response, err := client.ExecutePython(ctx, sandboxsupervisor.ExecutePythonRequest{
+			RequestID: "wait", SandboxID: "run-unresponsive", ExecutionID: "wait", Source: detachedCancellationWorkload,
+		})
+		if err != nil {
+			t.Errorf("unresponsive Init response: %v", err)
+		}
+		finished <- response
+	}()
+	workloadPID := waitForSandboxSignalHandler(t, initPID)
+	workloadGroup := observedResourceCgroup(t, strconv.Itoa(workloadPID))
+	pid, err := strconv.Atoi(initPID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Kill(pid, syscall.SIGSTOP); err != nil {
+		t.Fatal(err)
+	}
+	response := <-finished
+	if response.Error != nil || response.Result == nil || response.Result.TerminalReason != "timed_out" ||
+		response.Result.ExitCode != -1 || !response.Result.Truncated || response.Result.Stdout != "" || response.Result.Stderr != "" {
+		t.Fatalf("lost Init acknowledgement invented complete output or lost timeout evidence: %+v", response)
+	}
+	assertSandboxSupervisorErrorCode(t, exchangeSandboxSupervisorMessage(t, fixture.socketPath,
+		createSandboxWireRequest(t, "stale", "run-unresponsive", identity)), "sandbox_exists")
+	// Destroy waits for any in-progress teardown before asserting host state.
+	assertSandboxDestroyed(t, exchangeSandboxSupervisorMessage(t, fixture.socketPath,
+		destroySandboxWireRequest(t, "run-unresponsive")), "run-unresponsive")
+	if _, err := os.Stat(workloadGroup); !os.IsNotExist(err) {
+		t.Fatalf("unresponsive Init left the Execution cgroup behind: %v", err)
+	}
+	assertNoResourceCgroups(t)
+	if pids := sandboxProcessesForSubordinateMapping(t, 200000, 65536); len(pids) != 0 {
+		t.Fatalf("unresponsive Init retained descendants: %v", pids)
+	}
+	assertSandboxCreated(t, exchangeSandboxSupervisorMessage(t, fixture.socketPath,
+		createSandboxWireRequest(t, "replacement", "run-replacement", identity)), "run-replacement")
+	clean := executeSandboxPython(t, fixture, "run-replacement", "clean", "print('healthy')")
+	if clean.ExitCode != 0 || clean.Stdout != "healthy\n" {
+		t.Fatalf("unresponsive Init poisoned a replacement Sandbox: %+v", clean)
+	}
+}

--- a/tests/sandbox_lifecycle_linux_test.go
+++ b/tests/sandbox_lifecycle_linux_test.go
@@ -16,6 +16,24 @@ import (
 	"github.com/TH1NKING/Build-your-own-Docker-with-Go/internal/sandboxsupervisor"
 )
 
+// Readiness is announced only after a detached grandchild exists and retains
+// stdio. The parent alone installs SIGUSR1 for the host-observable handshake.
+const detachedCancellationWorkload = `import os, signal, time
+r, w = os.pipe()
+if os.fork() == 0:
+    os.close(r)
+    os.setsid()
+    if os.fork() != 0: os._exit(0)
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    os.write(w, b'R')
+    os.close(w)
+    while True: time.sleep(60)
+os.close(w)
+assert os.read(r, 1) == b'R'
+os.close(r)
+signal.signal(signal.SIGUSR1, lambda *_: None)
+signal.pause()`
+
 func TestSandboxLifecycleShutdownClosesIdleClients(t *testing.T) {
 	fixture, identity := installedSandboxExecutionFixture(t)
 	stop := startSandboxSupervisor(t, fixture, "--subuid-start", "200000", "--subgid-start", "300000", "--subid-count", "65536")
@@ -56,11 +74,12 @@ func TestSandboxLifecycleConcurrentDestroyTerminatesActiveExecution(t *testing.T
 	go func() {
 		response, _ := client.ExecutePython(ctx, sandboxsupervisor.ExecutePythonRequest{
 			RequestID: "active", SandboxID: "run-active", ExecutionID: "active",
-			Source: "import signal; signal.signal(signal.SIGUSR1, lambda *_: None); signal.pause()",
+			Source: detachedCancellationWorkload,
 		})
 		finished <- response
 	}()
 	workloadPID := waitForSandboxSignalHandler(t, initPID)
+	workloadGroup := observedResourceCgroup(t, strconv.Itoa(workloadPID))
 	// A rejected request closes its own connection without owning cancellation
 	// rights over the already running Execution or its Workspace.
 	busy, err := client.ExecutePython(ctx, sandboxsupervisor.ExecutePythonRequest{RequestID: "busy", SandboxID: "run-active", ExecutionID: "busy", Source: "print(42)"})
@@ -88,6 +107,10 @@ func TestSandboxLifecycleConcurrentDestroyTerminatesActiveExecution(t *testing.T
 	if pids := sandboxProcessesForSubordinateMapping(t, 200000, 65536); len(pids) != 0 {
 		t.Fatalf("destroy acknowledged surviving Workload: %v", pids)
 	}
+	if _, err := os.Stat(workloadGroup); !os.IsNotExist(err) {
+		t.Fatalf("destroy acknowledged before removing Execution cgroup: %v", err)
+	}
+	assertNoResourceCgroups(t)
 	assertSandboxSupervisorErrorCode(t, exchangeSandboxSupervisorMessage(t, fixture.socketPath, createSandboxWireRequest(t, "reuse", "run-active", identity)), "sandbox_exists")
 }
 
@@ -103,11 +126,12 @@ func TestSandboxLifecycleDisconnectDestroysActiveSandbox(t *testing.T) {
 	go func() {
 		_, err := sandboxsupervisor.NewClient(fixture.socketPath).ExecutePython(ctx, sandboxsupervisor.ExecutePythonRequest{
 			RequestID: "active", SandboxID: "run-abandoned", ExecutionID: "active",
-			Source: "import signal; signal.signal(signal.SIGUSR1, lambda *_: None); signal.pause()",
+			Source: detachedCancellationWorkload,
 		})
 		finished <- err
 	}()
 	workloadPID := waitForSandboxSignalHandler(t, initPID)
+	workloadGroup := observedResourceCgroup(t, strconv.Itoa(workloadPID))
 	cancel()
 	if err := <-finished; err == nil {
 		t.Fatal("cancelled client returned successful transport")
@@ -125,6 +149,13 @@ func TestSandboxLifecycleDisconnectDestroysActiveSandbox(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	if pids := sandboxProcessesForSubordinateMapping(t, 200000, 65536); len(pids) != 0 {
+		t.Fatalf("client cancellation retained detached descendants: %v", pids)
+	}
+	if _, err := os.Stat(workloadGroup); !os.IsNotExist(err) {
+		t.Fatalf("client cancellation retained Execution cgroup: %v", err)
+	}
+	assertNoResourceCgroups(t)
 	assertSandboxSupervisorErrorCode(t, exchangeSandboxSupervisorMessage(t, fixture.socketPath,
 		createSandboxWireRequest(t, "stale", "run-abandoned", identity)), "sandbox_exists")
 	assertSandboxCreated(t, exchangeSandboxSupervisorMessage(t, fixture.socketPath,

--- a/tests/sandbox_resource_protocol_linux_test.go
+++ b/tests/sandbox_resource_protocol_linux_test.go
@@ -13,9 +13,11 @@ import (
 func TestSandboxSupervisorAcceptsTrustedResourceBudgetConfiguration(t *testing.T) {
 	fixture := newSafeSandboxSupervisorFixture(t)
 	t.Cleanup(startSandboxSupervisor(t, fixture,
-		"--cpu-millis", "500", "--memory-bytes", "134217728", "--swap-bytes", "0", "--pids-limit", "32"))
+		"--cpu-millis", "500", "--memory-bytes", "134217728", "--swap-bytes", "0", "--pids-limit", "32", "--execution-timeout", "90s"))
 	assertSandboxSupervisorErrorCode(t, exchangeSandboxSupervisorMessage(t, fixture.socketPath,
 		[]byte(`{"schema":"sandbox-supervisor-request/v1","request_id":"budget-override","operation":"execute_python","parameters":{"sandbox_id":"run","execution_id":"step","source":"print(1)","cpu_millis":100000}}`)), "malformed_request")
+	assertSandboxSupervisorErrorCode(t, exchangeSandboxSupervisorMessage(t, fixture.socketPath,
+		[]byte(`{"schema":"sandbox-supervisor-request/v1","request_id":"timeout-override","operation":"execute_python","parameters":{"sandbox_id":"run","execution_id":"step","source":"print(1)","execution_timeout":"0s"}}`)), "malformed_request")
 }
 
 func TestSandboxSupervisorRejectsInvalidResourceBudgetsBeforeServing(t *testing.T) {
@@ -24,6 +26,7 @@ func TestSandboxSupervisorRejectsInvalidResourceBudgetsBeforeServing(t *testing.
 		{"--cpu-millis", "0"}, {"--cpu-millis", "9"}, {"--cpu-millis", "9223372036854775807"},
 		{"--memory-bytes", "0"}, {"--memory-bytes", "-1"}, {"--memory-bytes", "4097"},
 		{"--swap-bytes", "-1"}, {"--swap-bytes", "4097"}, {"--pids-limit", "0"}, {"--pids-limit", "-1"},
+		{"--execution-timeout", "0"}, {"--execution-timeout", "-1s"},
 	} {
 		t.Run(strings.Join(arguments, "="), func(t *testing.T) {
 			fixture := newSafeSandboxSupervisorFixture(t)


### PR DESCRIPTION
此前 Python 卡住时，固定通信超时会使整个 Sandbox 失效。现在由可信 Supervisor 限制每次 Execution 的运行时长；超时后终止 Python 及全部后代，完成清理再返回 `timed_out`，同一个 Init 和 Workspace 可以继续使用。

Closes #18

## 行为与边界

- 执行期限默认 60 秒，可通过 Supervisor 启动参数 `--execution-timeout` 配置；拒绝非正时长，Worker 请求和 Workload 不能覆盖期限。
- 从 `run` 放行前开始计时，持续输出不会延长期限。到期终止 Execution cgroup，确认没有活进程，消费 `exited`，完成 `reap → ready` 握手并删除 Execution cgroup 后，才允许复用 Sandbox。
- 执行期限与启动、回收、结果交付的通信期限分开，使超时后的收尾和配置超过 60 秒的正常执行都能完成。
- 每次执行负责结束自己的退出消息读取者，避免旧读取者消费后续执行的消息；握手不完整或清理无法确认时，使 Sandbox 失效。
- 客户端取消、显式销毁和 Supervisor 关闭继续遵循 T06 的整个 Sandbox 终止语义。终止原因根据可信期限与资源证据判断，普通 `sys.exit(137)` 仍返回 `exited`。

同步更新协议、配置说明及 T12 学习笔记，解释清理顺序、竞态处理和方案取舍。

## 验证

在 Ubuntu 24.04.4、Linux `7.0.0-30-generic`、Go `1.26.1` 中完成：

- `make check` 通过。
- 31 个顶层真实内核测试通过，覆盖默认 60 秒期限、配置 75 秒后正常执行 66 秒、连续超时复用、持续输出与脱离会话的后代、Init 无响应，以及既有资源预算和生命周期回归。
- Supervisor 与测试程序启用 `-race` 的 5 个定向测试通过，未报告数据竞争。
- Standards 与 Spec 审查均为 0 项发现。

上述结果来自虚拟机验证；GitHub Actions 状态以本 PR 的检查结果为准。
